### PR TITLE
Add Excavator Dispatch plugin (Excel + Google Contacts + WhatsApp)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ public/content/debug.log
 public/content/uploads
 !public/content/uploads/.gitkeep
 public/content/plugins/*
+!public/content/plugins/excavator-dispatch/
+public/content/plugins/excavator-dispatch/vendor
 public/content/themes/twenty*
 public/content/mu-plugins/*
 !public/content/mu-plugins/app.php

--- a/public/content/plugins/excavator-dispatch/README.md
+++ b/public/content/plugins/excavator-dispatch/README.md
@@ -1,0 +1,95 @@
+# Excavator Dispatch
+
+WordPress plugin per inviare comunicazioni WhatsApp su disponibilità di escavatori, leggendo l'elenco da un foglio Excel su Microsoft 365 e i destinatari da Google Contacts.
+
+## Architettura
+
+- **PHP 7.4+**, autoload PSR-4 (`InfraSe\ExcavatorDispatch\`).
+- Backend: WP REST API (`/wp-json/excavator-dispatch/v1/{machines,recipients,templates,dispatch}`).
+- Frontend admin: PHP + JS vanilla (nessun build step).
+- Storage: `wp_options` (credenziali crittografate con `sodium_crypto_secretbox`) + tabella custom `wp_excdis_dispatches` per lo storico invii.
+
+## Setup
+
+### 1. Installazione dipendenze (in `plugins/excavator-dispatch/`)
+
+```sh
+composer install --no-dev -o
+```
+
+Dipendenze runtime principali:
+- `microsoft/microsoft-graph` (Graph SDK, opzionale: il plugin chiama Graph direttamente via `wp_remote_*` per ridurre footprint)
+- `google/apiclient`
+- `guzzlehttp/guzzle`
+
+### 2. Chiave di crittografia
+
+Aggiungere in `wp-config.php` (almeno 32 caratteri):
+
+```php
+define('EXCDIS_ENCRYPTION_KEY', 'una-chiave-lunga-e-segreta-almeno-32-char');
+```
+
+Se omessa, il plugin deriva una chiave da `AUTH_KEY` (sconsigliato per produzione).
+
+### 3. Microsoft 365 (Graph API)
+
+1. Azure Portal → App registrations → Nuova registrazione.
+2. API permissions → Microsoft Graph → Application permissions: `Files.Read.All` (o `Sites.Read.All`) — grant admin consent.
+3. Generare Client Secret.
+4. Annotare Tenant ID, Client ID, Client Secret.
+5. Recuperare Drive ID e Item ID/Path del file Excel (Graph Explorer: `GET /drives/{driveId}/root/children`).
+6. Consigliato: definire una **Tabella Excel** (es. `Macchine`) sul foglio — il plugin la userà per intestazioni stabili.
+
+### 4. Google Contacts (People API)
+
+1. Google Cloud Console → progetto → abilitare People API.
+2. Creare un **Service Account**, generare chiave JSON.
+3. Abilitare **domain-wide delegation** sul service account.
+4. Workspace Admin → Security → API controls → Domain-wide delegation: aggiungere il Client ID del SA con scope `https://www.googleapis.com/auth/contacts.readonly`.
+5. Nella pagina Impostazioni: incollare il JSON e impostare l'email Workspace di cui il SA impersonerà i contatti.
+6. Opzionale: limitare ai gruppi indicando i `contactGroups/{id}` (uno per riga).
+
+### 5. WhatsApp Cloud API
+
+1. Meta for Developers → app Business → prodotto WhatsApp.
+2. Annotare WhatsApp Business Account ID, Phone Number ID, Access Token (consigliato system user long-lived).
+3. Approvare almeno un template (categoria UTILITY o MARKETING) nella lingua di lavoro (es. `it`).
+
+### 6. Mapping template
+
+Nella pagina Impostazioni → "Mapping template (JSON)":
+
+```json
+{
+  "avviso_macchine_disponibili": {
+    "body": [
+      "{count}",
+      "{list:Modello,Anno,Stato}"
+    ]
+  }
+}
+```
+
+Espressioni supportate nel mapping:
+- `{col:Colonna}` — valore della colonna dalla prima macchina selezionata
+- `{list:Col1,Col2}` — elenco puntato che concatena le colonne per ogni macchina selezionata
+- `{count}` — numero di macchine selezionate
+- testo libero — passato così com'è
+
+Le variabili di template Meta (`{{1}}`, `{{2}}`, …) sono popolate nell'ordine dell'array.
+
+## Uso
+
+Menu WP → **Excavator Dispatch**:
+1. La pagina mostra a sinistra le macchine filtrate dall'Excel, a destra i destinatari da Google Contacts.
+2. Selezionare manualmente macchine e destinatari (checkbox).
+3. Scegliere il template, verificare l'anteprima.
+4. Cliccare "Invia messaggio WhatsApp".
+5. L'esito di ciascun invio viene salvato in **Storico invii**.
+
+## Note
+
+- Cache transient (5 min) su Excel e Contacts; usare "Aggiorna" per forzare il refresh.
+- Throttle soft di ~20 messaggi/secondo. Per volumi alti spostare l'invio su un job in coda (fase 2).
+- Webhook delivery/read receipts non implementati nell'MVP.

--- a/public/content/plugins/excavator-dispatch/assets/css/dispatch.css
+++ b/public/content/plugins/excavator-dispatch/assets/css/dispatch.css
@@ -1,0 +1,85 @@
+.excdis-wrap { max-width: 1400px; }
+
+.excdis-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+@media (max-width: 1024px) {
+    .excdis-grid { grid-template-columns: 1fr; }
+}
+
+.excdis-panel {
+    background: #fff;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    min-height: 480px;
+}
+
+.excdis-panel__head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 14px;
+    border-bottom: 1px solid #dcdcde;
+    gap: 10px;
+}
+
+.excdis-panel__head h2 { margin: 0; font-size: 14px; }
+
+.excdis-panel__actions { display: flex; gap: 8px; }
+.excdis-panel__actions input[type="search"] { min-width: 200px; }
+
+.excdis-panel__body {
+    flex: 1;
+    overflow: auto;
+    max-height: 520px;
+}
+
+.excdis-panel__foot {
+    padding: 8px 14px;
+    border-top: 1px solid #dcdcde;
+    background: #f6f7f7;
+    font-size: 12px;
+}
+
+.excdis-send {
+    margin-top: 24px;
+    background: #fff;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+    padding: 16px;
+}
+
+.excdis-send label { font-weight: 600; display: block; margin-bottom: 6px; }
+.excdis-send select { min-width: 360px; }
+
+.excdis-preview {
+    margin: 12px 0;
+}
+
+.excdis-preview pre {
+    background: #f6f7f7;
+    padding: 12px;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    max-height: 240px;
+    overflow: auto;
+    white-space: pre-wrap;
+}
+
+.excdis-status {
+    margin-top: 12px;
+    padding: 10px 14px;
+    border-radius: 4px;
+    min-height: 1.2em;
+}
+.excdis-status:empty { display: none; }
+.excdis-status--info    { background: #f0f6fc; border-left: 4px solid #2271b1; }
+.excdis-status--success { background: #edfaef; border-left: 4px solid #00a32a; }
+.excdis-status--warning { background: #fcf9e8; border-left: 4px solid #dba617; }
+.excdis-status--error   { background: #fcf0f1; border-left: 4px solid #d63638; }

--- a/public/content/plugins/excavator-dispatch/assets/js/dispatch.js
+++ b/public/content/plugins/excavator-dispatch/assets/js/dispatch.js
@@ -170,7 +170,7 @@
 
         const recipients = state.recipients
             .filter((r) => state.selectedRecipients.has(r.resource_name))
-            .map((r) => ({ phone: r.phone, name: r.name }));
+            .map((r) => ({ phone: r.phone, name: r.name, organization: r.organization || '' }));
 
         setStatus(EXCDIS.i18n.loading, 'info');
         $('#excdis-send').disabled = true;

--- a/public/content/plugins/excavator-dispatch/assets/js/dispatch.js
+++ b/public/content/plugins/excavator-dispatch/assets/js/dispatch.js
@@ -1,0 +1,269 @@
+(function () {
+    'use strict';
+
+    const state = {
+        machines: [],
+        machineFilter: '',
+        selectedMachines: new Set(),
+        recipients: [],
+        recipientFilter: '',
+        selectedRecipients: new Set(),
+        templates: [],
+        selectedTemplate: '',
+    };
+
+    const $ = (sel) => document.querySelector(sel);
+
+    function api(path, options = {}) {
+        const url = EXCDIS.restUrl + path.replace(/^\//, '');
+        return fetch(url, {
+            credentials: 'same-origin',
+            ...options,
+            headers: {
+                'X-WP-Nonce': EXCDIS.nonce,
+                'Accept': 'application/json',
+                ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+                ...(options.headers || {}),
+            },
+        }).then(async (r) => {
+            const data = await r.json().catch(() => ({}));
+            if (!r.ok) {
+                throw new Error(data.message || ('HTTP ' + r.status));
+            }
+            return data;
+        });
+    }
+
+    function machineId(row) {
+        if (EXCDIS.idCol && row[EXCDIS.idCol] != null && row[EXCDIS.idCol] !== '') {
+            return String(row[EXCDIS.idCol]);
+        }
+        return String(row.__row != null ? row.__row : '');
+    }
+
+    function machineLabel(row) {
+        const cols = (EXCDIS.labels && EXCDIS.labels.length)
+            ? EXCDIS.labels
+            : Object.keys(row).filter((k) => k !== '__row').slice(0, 4);
+        return cols.map((c) => row[c]).filter((v) => v != null && v !== '').join(' · ');
+    }
+
+    function renderMachines() {
+        const tbody = $('#excdis-machines-table tbody');
+        const q = state.machineFilter.trim().toLowerCase();
+        const filtered = state.machines.filter((m) => !q || machineLabel(m).toLowerCase().includes(q));
+        if (!filtered.length) {
+            tbody.innerHTML = '<tr><td colspan="2">' + EXCDIS.i18n.noResults + '</td></tr>';
+        } else {
+            tbody.innerHTML = filtered.map((m) => {
+                const id = machineId(m);
+                const checked = state.selectedMachines.has(id) ? 'checked' : '';
+                return '<tr>'
+                    + '<td><input type="checkbox" class="excdis-m-cb" data-id="' + escapeAttr(id) + '" ' + checked + ' /></td>'
+                    + '<td>' + escapeHtml(machineLabel(m)) + '</td>'
+                    + '</tr>';
+            }).join('');
+        }
+        $('#excdis-machines-count').textContent = String(state.selectedMachines.size);
+        updatePreview();
+    }
+
+    function renderRecipients() {
+        const tbody = $('#excdis-recipients-table tbody');
+        const q = state.recipientFilter.trim().toLowerCase();
+        const filtered = state.recipients.filter((r) => {
+            if (!q) return true;
+            return (r.name || '').toLowerCase().includes(q)
+                || (r.organization || '').toLowerCase().includes(q)
+                || (r.phone || '').toLowerCase().includes(q);
+        });
+        if (!filtered.length) {
+            tbody.innerHTML = '<tr><td colspan="3">' + EXCDIS.i18n.noResults + '</td></tr>';
+        } else {
+            tbody.innerHTML = filtered.map((r) => {
+                const id = r.resource_name;
+                const checked = state.selectedRecipients.has(id) ? 'checked' : '';
+                const label = r.organization ? (r.name + ' — ' + r.organization) : r.name;
+                return '<tr>'
+                    + '<td><input type="checkbox" class="excdis-r-cb" data-id="' + escapeAttr(id) + '" ' + checked + ' /></td>'
+                    + '<td>' + escapeHtml(label || '(senza nome)') + '</td>'
+                    + '<td>' + escapeHtml(r.phone || '') + '</td>'
+                    + '</tr>';
+            }).join('');
+        }
+        $('#excdis-recipients-count').textContent = String(state.selectedRecipients.size);
+    }
+
+    function renderTemplates() {
+        const sel = $('#excdis-template');
+        if (!state.templates.length) {
+            sel.innerHTML = '<option value="">' + EXCDIS.i18n.noResults + '</option>';
+            return;
+        }
+        sel.innerHTML = state.templates.map((t, i) =>
+            '<option value="' + escapeAttr(t.name) + '"' + (i === 0 ? ' selected' : '') + '>'
+            + escapeHtml(t.name + '  [' + t.language + ']')
+            + '</option>'
+        ).join('');
+        state.selectedTemplate = sel.value;
+        updatePreview();
+    }
+
+    function updatePreview() {
+        const pre = $('#excdis-preview');
+        if (!pre) return;
+        const template = state.templates.find((t) => t.name === state.selectedTemplate);
+        const selectedMachines = state.machines.filter((m) => state.selectedMachines.has(machineId(m)));
+        if (!template) {
+            pre.textContent = '';
+            return;
+        }
+        const body = (template.components || []).find((c) => c.type === 'BODY');
+        let text = body ? (body.text || '') : '';
+        text += '\n\n--- Macchine selezionate (' + selectedMachines.length + ') ---\n';
+        text += selectedMachines.map((m) => '- ' + machineLabel(m)).join('\n');
+        pre.textContent = text;
+    }
+
+    async function loadMachines(refresh = false) {
+        const tbody = $('#excdis-machines-table tbody');
+        tbody.innerHTML = '<tr><td colspan="2">' + EXCDIS.i18n.loading + '</td></tr>';
+        try {
+            const data = await api('machines' + (refresh ? '?refresh=1' : ''));
+            state.machines = data.machines || [];
+            renderMachines();
+        } catch (e) {
+            tbody.innerHTML = '<tr><td colspan="2"><span style="color:#b00">' + escapeHtml(e.message) + '</span></td></tr>';
+        }
+    }
+
+    async function loadRecipients(refresh = false) {
+        const tbody = $('#excdis-recipients-table tbody');
+        tbody.innerHTML = '<tr><td colspan="3">' + EXCDIS.i18n.loading + '</td></tr>';
+        try {
+            const data = await api('recipients' + (refresh ? '?refresh=1' : ''));
+            state.recipients = data.recipients || [];
+            renderRecipients();
+        } catch (e) {
+            tbody.innerHTML = '<tr><td colspan="3"><span style="color:#b00">' + escapeHtml(e.message) + '</span></td></tr>';
+        }
+    }
+
+    async function loadTemplates() {
+        try {
+            const data = await api('templates');
+            state.templates = data.templates || [];
+            renderTemplates();
+        } catch (e) {
+            $('#excdis-template').innerHTML = '<option value="">' + escapeHtml(e.message) + '</option>';
+        }
+    }
+
+    async function sendDispatch() {
+        if (!state.selectedTemplate) {
+            return setStatus(EXCDIS.i18n.noResults, 'error');
+        }
+        if (!state.selectedMachines.size || !state.selectedRecipients.size) {
+            return setStatus('Seleziona almeno una macchina e un destinatario.', 'error');
+        }
+        if (!window.confirm(EXCDIS.i18n.confirm)) return;
+
+        const recipients = state.recipients
+            .filter((r) => state.selectedRecipients.has(r.resource_name))
+            .map((r) => ({ phone: r.phone, name: r.name }));
+
+        setStatus(EXCDIS.i18n.loading, 'info');
+        $('#excdis-send').disabled = true;
+        try {
+            const data = await api('dispatch', {
+                method: 'POST',
+                body: JSON.stringify({
+                    template: state.selectedTemplate,
+                    machine_ids: Array.from(state.selectedMachines),
+                    recipients,
+                }),
+            });
+            setStatus('Inviati: ' + data.success + ' / ' + data.total + ' — Errori: ' + data.errors, data.errors ? 'warning' : 'success');
+        } catch (e) {
+            setStatus(e.message, 'error');
+        } finally {
+            $('#excdis-send').disabled = false;
+        }
+    }
+
+    function setStatus(msg, kind) {
+        const el = $('#excdis-status');
+        el.className = 'excdis-status excdis-status--' + (kind || 'info');
+        el.textContent = msg;
+    }
+
+    function escapeHtml(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+    }
+    function escapeAttr(s) { return escapeHtml(s); }
+
+    function bind() {
+        $('#excdis-machine-search').addEventListener('input', (e) => { state.machineFilter = e.target.value; renderMachines(); });
+        $('#excdis-recipient-search').addEventListener('input', (e) => { state.recipientFilter = e.target.value; renderRecipients(); });
+        $('#excdis-machines-refresh').addEventListener('click', (e) => { e.preventDefault(); loadMachines(true); });
+        $('#excdis-recipients-refresh').addEventListener('click', (e) => { e.preventDefault(); loadRecipients(true); });
+
+        $('#excdis-machines-table').addEventListener('change', (e) => {
+            if (e.target.classList.contains('excdis-m-cb')) {
+                const id = e.target.dataset.id;
+                if (e.target.checked) state.selectedMachines.add(id);
+                else state.selectedMachines.delete(id);
+                $('#excdis-machines-count').textContent = String(state.selectedMachines.size);
+                updatePreview();
+            }
+        });
+        $('#excdis-machines-all').addEventListener('change', (e) => {
+            const q = state.machineFilter.trim().toLowerCase();
+            state.machines.forEach((m) => {
+                if (q && !machineLabel(m).toLowerCase().includes(q)) return;
+                const id = machineId(m);
+                if (e.target.checked) state.selectedMachines.add(id);
+                else state.selectedMachines.delete(id);
+            });
+            renderMachines();
+        });
+
+        $('#excdis-recipients-table').addEventListener('change', (e) => {
+            if (e.target.classList.contains('excdis-r-cb')) {
+                const id = e.target.dataset.id;
+                if (e.target.checked) state.selectedRecipients.add(id);
+                else state.selectedRecipients.delete(id);
+                $('#excdis-recipients-count').textContent = String(state.selectedRecipients.size);
+            }
+        });
+        $('#excdis-recipients-all').addEventListener('change', (e) => {
+            const q = state.recipientFilter.trim().toLowerCase();
+            state.recipients.forEach((r) => {
+                if (q) {
+                    const hay = (r.name + ' ' + (r.organization || '') + ' ' + (r.phone || '')).toLowerCase();
+                    if (!hay.includes(q)) return;
+                }
+                if (e.target.checked) state.selectedRecipients.add(r.resource_name);
+                else state.selectedRecipients.delete(r.resource_name);
+            });
+            renderRecipients();
+        });
+
+        $('#excdis-template').addEventListener('change', (e) => {
+            state.selectedTemplate = e.target.value;
+            updatePreview();
+        });
+
+        $('#excdis-send').addEventListener('click', (e) => { e.preventDefault(); sendDispatch(); });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (typeof EXCDIS === 'undefined') return;
+        bind();
+        loadMachines();
+        loadRecipients();
+        loadTemplates();
+    });
+})();

--- a/public/content/plugins/excavator-dispatch/composer.json
+++ b/public/content/plugins/excavator-dispatch/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "infrase/excavator-dispatch",
+    "description": "WordPress plugin to dispatch WhatsApp messages about available excavators to filtered Google Contacts.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0+",
+    "require": {
+        "php": ">=7.4",
+        "microsoft/microsoft-graph": "^2.0",
+        "google/apiclient": "^2.15",
+        "guzzlehttp/guzzle": "^7.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "InfraSe\\ExcavatorDispatch\\": "src/"
+        }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    }
+}

--- a/public/content/plugins/excavator-dispatch/excavator-dispatch.php
+++ b/public/content/plugins/excavator-dispatch/excavator-dispatch.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Plugin Name: Excavator Dispatch
+ * Description: Filtra macchine da un foglio Excel su M365, destinatari da Google Contacts, e invia un template WhatsApp via Cloud API.
+ * Version: 0.1.0
+ * Requires PHP: 7.4
+ * Author: InfraSe
+ * License: GPL-2.0+
+ * Text Domain: excavator-dispatch
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('EXCDIS_VERSION', '0.1.0');
+define('EXCDIS_FILE', __FILE__);
+define('EXCDIS_DIR', __DIR__);
+define('EXCDIS_URL', plugin_dir_url(__FILE__));
+
+$autoload = __DIR__ . '/vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+}
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'InfraSe\\ExcavatorDispatch\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+    $relative = substr($class, strlen($prefix));
+    $path = __DIR__ . '/src/' . str_replace('\\', '/', $relative) . '.php';
+    if (is_readable($path)) {
+        require_once $path;
+    }
+});
+
+register_activation_hook(__FILE__, [\InfraSe\ExcavatorDispatch\Plugin::class, 'activate']);
+register_deactivation_hook(__FILE__, [\InfraSe\ExcavatorDispatch\Plugin::class, 'deactivate']);
+
+add_action('plugins_loaded', static function (): void {
+    \InfraSe\ExcavatorDispatch\Plugin::instance()->boot();
+});

--- a/public/content/plugins/excavator-dispatch/src/Admin/DispatchPage.php
+++ b/public/content/plugins/excavator-dispatch/src/Admin/DispatchPage.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Admin;
+
+use InfraSe\ExcavatorDispatch\Plugin;
+use InfraSe\ExcavatorDispatch\Support\Settings;
+
+final class DispatchPage
+{
+    public function register(): void
+    {
+        add_action('admin_menu', [$this, 'add_menu']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue']);
+    }
+
+    public function add_menu(): void
+    {
+        add_menu_page(
+            __('Excavator Dispatch', 'excavator-dispatch'),
+            __('Excavator Dispatch', 'excavator-dispatch'),
+            Plugin::CAPABILITY,
+            Plugin::MENU_SLUG,
+            [$this, 'render'],
+            'dashicons-megaphone',
+            58
+        );
+    }
+
+    public function enqueue(string $hook): void
+    {
+        if (strpos($hook, Plugin::MENU_SLUG) === false) {
+            return;
+        }
+        wp_enqueue_style(
+            'excdis-admin',
+            EXCDIS_URL . 'assets/css/dispatch.css',
+            [],
+            EXCDIS_VERSION
+        );
+        wp_enqueue_script(
+            'excdis-admin',
+            EXCDIS_URL . 'assets/js/dispatch.js',
+            [],
+            EXCDIS_VERSION,
+            true
+        );
+        wp_localize_script('excdis-admin', 'EXCDIS', [
+            'restUrl' => esc_url_raw(rest_url(Plugin::REST_NS . '/')),
+            'nonce'   => wp_create_nonce('wp_rest'),
+            'idCol'   => (string) Settings::get('machine_id_column', ''),
+            'labels'  => (array) Settings::get('machine_label_columns', []),
+            'i18n'    => [
+                'loading'   => __('Caricamento…', 'excavator-dispatch'),
+                'noResults' => __('Nessun risultato', 'excavator-dispatch'),
+                'send'      => __('Invia messaggio WhatsApp', 'excavator-dispatch'),
+                'confirm'   => __('Confermi l\'invio?', 'excavator-dispatch'),
+            ],
+        ]);
+    }
+
+    public function render(): void
+    {
+        if (!current_user_can(Plugin::CAPABILITY)) {
+            return;
+        }
+        $configured = Settings::is_configured();
+        ?>
+        <div class="wrap excdis-wrap">
+            <h1><?php esc_html_e('Excavator Dispatch', 'excavator-dispatch'); ?></h1>
+
+            <?php if (!$configured): ?>
+                <div class="notice notice-warning">
+                    <p>
+                        <?php
+                        printf(
+                            /* translators: %s: settings link */
+                            esc_html__('Configurazione incompleta. Apri le %s prima di usare la pagina.', 'excavator-dispatch'),
+                            '<a href="' . esc_url(admin_url('admin.php?page=' . Plugin::MENU_SLUG . '-settings')) . '">'
+                                . esc_html__('Impostazioni', 'excavator-dispatch')
+                                . '</a>'
+                        );
+                        ?>
+                    </p>
+                </div>
+            <?php endif; ?>
+
+            <div class="excdis-grid">
+                <section class="excdis-panel">
+                    <header class="excdis-panel__head">
+                        <h2><?php esc_html_e('Macchine disponibili', 'excavator-dispatch'); ?></h2>
+                        <div class="excdis-panel__actions">
+                            <input type="search" id="excdis-machine-search" placeholder="<?php esc_attr_e('Cerca…', 'excavator-dispatch'); ?>" />
+                            <button class="button" id="excdis-machines-refresh"><?php esc_html_e('Aggiorna', 'excavator-dispatch'); ?></button>
+                        </div>
+                    </header>
+                    <div class="excdis-panel__body">
+                        <table class="widefat striped" id="excdis-machines-table">
+                            <thead>
+                                <tr>
+                                    <th class="check-column"><input type="checkbox" id="excdis-machines-all" /></th>
+                                    <th><?php esc_html_e('Macchina', 'excavator-dispatch'); ?></th>
+                                </tr>
+                            </thead>
+                            <tbody><tr><td colspan="2"><?php esc_html_e('Caricamento…', 'excavator-dispatch'); ?></td></tr></tbody>
+                        </table>
+                    </div>
+                    <footer class="excdis-panel__foot">
+                        <span id="excdis-machines-count">0</span> <?php esc_html_e('selezionate', 'excavator-dispatch'); ?>
+                    </footer>
+                </section>
+
+                <section class="excdis-panel">
+                    <header class="excdis-panel__head">
+                        <h2><?php esc_html_e('Destinatari', 'excavator-dispatch'); ?></h2>
+                        <div class="excdis-panel__actions">
+                            <input type="search" id="excdis-recipient-search" placeholder="<?php esc_attr_e('Cerca…', 'excavator-dispatch'); ?>" />
+                            <button class="button" id="excdis-recipients-refresh"><?php esc_html_e('Aggiorna', 'excavator-dispatch'); ?></button>
+                        </div>
+                    </header>
+                    <div class="excdis-panel__body">
+                        <table class="widefat striped" id="excdis-recipients-table">
+                            <thead>
+                                <tr>
+                                    <th class="check-column"><input type="checkbox" id="excdis-recipients-all" /></th>
+                                    <th><?php esc_html_e('Nome', 'excavator-dispatch'); ?></th>
+                                    <th><?php esc_html_e('Telefono', 'excavator-dispatch'); ?></th>
+                                </tr>
+                            </thead>
+                            <tbody><tr><td colspan="3"><?php esc_html_e('Caricamento…', 'excavator-dispatch'); ?></td></tr></tbody>
+                        </table>
+                    </div>
+                    <footer class="excdis-panel__foot">
+                        <span id="excdis-recipients-count">0</span> <?php esc_html_e('selezionati', 'excavator-dispatch'); ?>
+                    </footer>
+                </section>
+            </div>
+
+            <section class="excdis-send">
+                <label for="excdis-template"><?php esc_html_e('Template WhatsApp', 'excavator-dispatch'); ?></label>
+                <select id="excdis-template"><option><?php esc_html_e('Caricamento…', 'excavator-dispatch'); ?></option></select>
+
+                <details class="excdis-preview">
+                    <summary><?php esc_html_e('Anteprima messaggio', 'excavator-dispatch'); ?></summary>
+                    <pre id="excdis-preview"></pre>
+                </details>
+
+                <button class="button button-primary button-hero" id="excdis-send"><?php esc_html_e('Invia messaggio WhatsApp', 'excavator-dispatch'); ?></button>
+                <div id="excdis-status" class="excdis-status"></div>
+            </section>
+        </div>
+        <?php
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Admin/LogPage.php
+++ b/public/content/plugins/excavator-dispatch/src/Admin/LogPage.php
@@ -11,9 +11,32 @@ final class LogPage
 {
     private const SLUG = Plugin::MENU_SLUG . '-log';
 
+    private const NONCE_PRUNE = 'excdis_log_prune';
+
     public function register(): void
     {
         add_action('admin_menu', [$this, 'add_submenu'], 30);
+        add_action('admin_post_excdis_prune_log', [$this, 'handle_prune']);
+    }
+
+    public function handle_prune(): void
+    {
+        if (!current_user_can(Plugin::CAPABILITY)) {
+            wp_die('forbidden');
+        }
+        check_admin_referer(self::NONCE_PRUNE);
+        $mode = sanitize_key((string) ($_POST['mode'] ?? 'older'));
+        if ($mode === 'all') {
+            $count = Logger::delete_all();
+        } else {
+            $days = max(0, (int) ($_POST['days'] ?? 30));
+            $count = Logger::delete_older_than($days);
+        }
+        wp_safe_redirect(add_query_arg(
+            ['page' => self::SLUG, 'pruned' => $count],
+            admin_url('admin.php')
+        ));
+        exit;
     }
 
     public function add_submenu(): void
@@ -37,6 +60,28 @@ final class LogPage
         ?>
         <div class="wrap">
             <h1><?php esc_html_e('Storico invii', 'excavator-dispatch'); ?></h1>
+            <?php if (isset($_GET['pruned'])): ?>
+                <div class="notice notice-success is-dismissible"><p>
+                    <?php printf(
+                        /* translators: %d is the number of deleted rows. */
+                        esc_html__('Eliminate %d righe dallo storico.', 'excavator-dispatch'),
+                        (int) $_GET['pruned']
+                    ); ?>
+                </p></div>
+            <?php endif; ?>
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="margin: 12px 0; display: flex; align-items: center; gap: 10px; flex-wrap: wrap;">
+                <input type="hidden" name="action" value="excdis_prune_log" />
+                <?php wp_nonce_field(self::NONCE_PRUNE); ?>
+                <label>
+                    <?php esc_html_e('Elimina righe più vecchie di', 'excavator-dispatch'); ?>
+                    <input type="number" name="days" value="30" min="0" step="1" style="width: 70px;" />
+                    <?php esc_html_e('giorni', 'excavator-dispatch'); ?>
+                </label>
+                <button class="button" name="mode" value="older"><?php esc_html_e('Pulisci', 'excavator-dispatch'); ?></button>
+                <button class="button button-link-delete" name="mode" value="all"
+                    onclick="return confirm('<?php echo esc_js(__('Eliminare TUTTO lo storico?', 'excavator-dispatch')); ?>');"
+                ><?php esc_html_e('Cancella tutto', 'excavator-dispatch'); ?></button>
+            </form>
             <style>
                 .excdis-log { table-layout: fixed; width: 100%; }
                 .excdis-log th, .excdis-log td { word-wrap: break-word; overflow-wrap: anywhere; vertical-align: top; }

--- a/public/content/plugins/excavator-dispatch/src/Admin/LogPage.php
+++ b/public/content/plugins/excavator-dispatch/src/Admin/LogPage.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Admin;
+
+use InfraSe\ExcavatorDispatch\Plugin;
+use InfraSe\ExcavatorDispatch\Support\Logger;
+
+final class LogPage
+{
+    private const SLUG = Plugin::MENU_SLUG . '-log';
+
+    public function register(): void
+    {
+        add_action('admin_menu', [$this, 'add_submenu'], 30);
+    }
+
+    public function add_submenu(): void
+    {
+        add_submenu_page(
+            Plugin::MENU_SLUG,
+            __('Storico invii', 'excavator-dispatch'),
+            __('Storico invii', 'excavator-dispatch'),
+            Plugin::CAPABILITY,
+            self::SLUG,
+            [$this, 'render']
+        );
+    }
+
+    public function render(): void
+    {
+        if (!current_user_can(Plugin::CAPABILITY)) {
+            return;
+        }
+        $rows = Logger::recent(100);
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Storico invii', 'excavator-dispatch'); ?></h1>
+            <table class="widefat striped">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e('Data', 'excavator-dispatch'); ?></th>
+                        <th><?php esc_html_e('Utente', 'excavator-dispatch'); ?></th>
+                        <th><?php esc_html_e('Template', 'excavator-dispatch'); ?></th>
+                        <th><?php esc_html_e('Macchine', 'excavator-dispatch'); ?></th>
+                        <th><?php esc_html_e('Destinatari', 'excavator-dispatch'); ?></th>
+                        <th><?php esc_html_e('OK', 'excavator-dispatch'); ?></th>
+                        <th><?php esc_html_e('Errori', 'excavator-dispatch'); ?></th>
+                        <th><?php esc_html_e('Dettagli', 'excavator-dispatch'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php if (empty($rows)): ?>
+                    <tr><td colspan="8"><?php esc_html_e('Nessun invio.', 'excavator-dispatch'); ?></td></tr>
+                <?php else: foreach ($rows as $row): $user = get_userdata((int) $row['user_id']); ?>
+                    <tr>
+                        <td><?php echo esc_html((string) $row['created_at']); ?></td>
+                        <td><?php echo esc_html($user ? $user->user_login : '#' . (int) $row['user_id']); ?></td>
+                        <td><?php echo esc_html((string) $row['template_name']); ?> <small>(<?php echo esc_html((string) $row['template_language']); ?>)</small></td>
+                        <td><?php echo (int) $row['machine_count']; ?></td>
+                        <td><?php echo (int) $row['recipient_count']; ?></td>
+                        <td><?php echo (int) $row['success_count']; ?></td>
+                        <td><?php echo (int) $row['error_count']; ?></td>
+                        <td><details><summary><?php esc_html_e('Mostra', 'excavator-dispatch'); ?></summary><pre style="max-height:300px;overflow:auto"><?php echo esc_html((string) $row['details']); ?></pre></details></td>
+                    </tr>
+                <?php endforeach; endif; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Admin/LogPage.php
+++ b/public/content/plugins/excavator-dispatch/src/Admin/LogPage.php
@@ -37,7 +37,27 @@ final class LogPage
         ?>
         <div class="wrap">
             <h1><?php esc_html_e('Storico invii', 'excavator-dispatch'); ?></h1>
-            <table class="widefat striped">
+            <style>
+                .excdis-log { table-layout: fixed; width: 100%; }
+                .excdis-log th, .excdis-log td { word-wrap: break-word; overflow-wrap: anywhere; vertical-align: top; }
+                .excdis-log col.c-date { width: 140px; }
+                .excdis-log col.c-user { width: 110px; }
+                .excdis-log col.c-tpl { width: 200px; }
+                .excdis-log col.c-num { width: 70px; }
+                .excdis-log col.c-det { width: auto; }
+                .excdis-log .excdis-det { white-space: pre-wrap; word-break: break-word; max-height: 320px; overflow: auto; background: #f6f7f7; padding: 10px; border: 1px solid #dcdcde; border-radius: 4px; margin: 6px 0 0; font-size: 12px; }
+            </style>
+            <table class="widefat striped excdis-log">
+                <colgroup>
+                    <col class="c-date" />
+                    <col class="c-user" />
+                    <col class="c-tpl" />
+                    <col class="c-num" />
+                    <col class="c-num" />
+                    <col class="c-num" />
+                    <col class="c-num" />
+                    <col class="c-det" />
+                </colgroup>
                 <thead>
                     <tr>
                         <th><?php esc_html_e('Data', 'excavator-dispatch'); ?></th>
@@ -62,7 +82,7 @@ final class LogPage
                         <td><?php echo (int) $row['recipient_count']; ?></td>
                         <td><?php echo (int) $row['success_count']; ?></td>
                         <td><?php echo (int) $row['error_count']; ?></td>
-                        <td><details><summary><?php esc_html_e('Mostra', 'excavator-dispatch'); ?></summary><pre style="max-height:300px;overflow:auto"><?php echo esc_html((string) $row['details']); ?></pre></details></td>
+                        <td><details><summary><?php esc_html_e('Mostra', 'excavator-dispatch'); ?></summary><pre class="excdis-det"><?php echo esc_html((string) $row['details']); ?></pre></details></td>
                     </tr>
                 <?php endforeach; endif; ?>
                 </tbody>

--- a/public/content/plugins/excavator-dispatch/src/Admin/SettingsPage.php
+++ b/public/content/plugins/excavator-dispatch/src/Admin/SettingsPage.php
@@ -68,6 +68,7 @@ final class SettingsPage
             'whatsapp_waba_id'           => sanitize_text_field((string) ($input['whatsapp_waba_id'] ?? '')),
             'whatsapp_access_token'      => (string) ($input['whatsapp_access_token'] ?? ''),
             'whatsapp_default_language'  => sanitize_text_field((string) ($input['whatsapp_default_language'] ?? 'it')),
+            'image_url_pattern'          => esc_url_raw((string) ($input['image_url_pattern'] ?? '')),
             'machine_id_column'          => sanitize_text_field((string) ($input['machine_id_column'] ?? '')),
             'machine_label_columns'      => array_filter(array_map('sanitize_text_field', array_map('trim', explode(',', (string) ($input['machine_label_columns'] ?? ''))))),
             'machine_filters'            => $this->parse_filters((string) ($input['machine_filters'] ?? '')),
@@ -147,6 +148,7 @@ final class SettingsPage
                     <?php $this->row('WhatsApp Business Account (WABA) ID', 'whatsapp_waba_id', $s); ?>
                     <?php $this->secret_row('Access Token (long-lived)', 'whatsapp_access_token', $s); ?>
                     <?php $this->row('Lingua template di default', 'whatsapp_default_language', $s, 'es: it, en_US'); ?>
+                    <?php $this->row('Image URL pattern (per template carousel — {value} è il segnaposto)', 'image_url_pattern', $s, 'es: https://wa.sertech.srl/wp-content/uploads/{value}.jpg'); ?>
                 </table>
 
                 <h2><?php esc_html_e('Macchine — colonne e filtri', 'excavator-dispatch'); ?></h2>

--- a/public/content/plugins/excavator-dispatch/src/Admin/SettingsPage.php
+++ b/public/content/plugins/excavator-dispatch/src/Admin/SettingsPage.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Admin;
+
+use InfraSe\ExcavatorDispatch\Plugin;
+use InfraSe\ExcavatorDispatch\Support\Cache;
+use InfraSe\ExcavatorDispatch\Support\Settings;
+
+final class SettingsPage
+{
+    private const SLUG = Plugin::MENU_SLUG . '-settings';
+    private const NONCE = 'excdis_settings_save';
+
+    public function register(): void
+    {
+        add_action('admin_menu', [$this, 'add_submenu'], 20);
+        add_action('admin_post_excdis_save_settings', [$this, 'handle_save']);
+    }
+
+    public function add_submenu(): void
+    {
+        add_submenu_page(
+            Plugin::MENU_SLUG,
+            __('Impostazioni', 'excavator-dispatch'),
+            __('Impostazioni', 'excavator-dispatch'),
+            Plugin::CAPABILITY,
+            self::SLUG,
+            [$this, 'render']
+        );
+    }
+
+    public function handle_save(): void
+    {
+        if (!current_user_can(Plugin::CAPABILITY)) {
+            wp_die('forbidden');
+        }
+        check_admin_referer(self::NONCE);
+
+        $input = wp_unslash($_POST['excdis'] ?? []);
+        if (!is_array($input)) {
+            $input = [];
+        }
+
+        $current = Settings::all();
+        $secrets = ['m365_client_secret', 'google_service_account_json', 'whatsapp_access_token'];
+        foreach ($secrets as $key) {
+            if (!isset($input[$key]) || $input[$key] === '') {
+                $input[$key] = $current[$key] ?? '';
+            }
+        }
+
+        $clean = [
+            'm365_tenant_id'             => sanitize_text_field((string) ($input['m365_tenant_id'] ?? '')),
+            'm365_client_id'             => sanitize_text_field((string) ($input['m365_client_id'] ?? '')),
+            'm365_client_secret'         => (string) ($input['m365_client_secret'] ?? ''),
+            'm365_drive_id'              => sanitize_text_field((string) ($input['m365_drive_id'] ?? '')),
+            'm365_item_id'               => sanitize_text_field((string) ($input['m365_item_id'] ?? '')),
+            'm365_file_path'             => sanitize_text_field((string) ($input['m365_file_path'] ?? '')),
+            'm365_worksheet'             => sanitize_text_field((string) ($input['m365_worksheet'] ?? '')),
+            'm365_table_name'            => sanitize_text_field((string) ($input['m365_table_name'] ?? '')),
+            'google_service_account_json'=> (string) ($input['google_service_account_json'] ?? ''),
+            'google_impersonate_email'   => sanitize_email((string) ($input['google_impersonate_email'] ?? '')),
+            'google_group_ids'           => array_filter(array_map('sanitize_text_field', explode("\n", (string) ($input['google_group_ids'] ?? '')))),
+            'default_country_code'       => sanitize_text_field((string) ($input['default_country_code'] ?? '')),
+            'whatsapp_phone_number_id'   => sanitize_text_field((string) ($input['whatsapp_phone_number_id'] ?? '')),
+            'whatsapp_waba_id'           => sanitize_text_field((string) ($input['whatsapp_waba_id'] ?? '')),
+            'whatsapp_access_token'      => (string) ($input['whatsapp_access_token'] ?? ''),
+            'whatsapp_default_language'  => sanitize_text_field((string) ($input['whatsapp_default_language'] ?? 'it')),
+            'machine_id_column'          => sanitize_text_field((string) ($input['machine_id_column'] ?? '')),
+            'machine_label_columns'      => array_filter(array_map('sanitize_text_field', array_map('trim', explode(',', (string) ($input['machine_label_columns'] ?? ''))))),
+            'machine_filters'            => $this->parse_filters((string) ($input['machine_filters'] ?? '')),
+            'recipients_require_phone'   => !empty($input['recipients_require_phone']),
+            'recipients_name_regex'      => (string) ($input['recipients_name_regex'] ?? ''),
+            'template_mappings'          => $this->parse_mappings((string) ($input['template_mappings'] ?? '')),
+        ];
+
+        Settings::save($clean);
+        Cache::flush();
+
+        wp_safe_redirect(add_query_arg(['page' => self::SLUG, 'updated' => '1'], admin_url('admin.php')));
+        exit;
+    }
+
+    private function parse_filters(string $raw): array
+    {
+        $out = [];
+        foreach (preg_split('/\r?\n/', $raw) ?: [] as $line) {
+            $line = trim($line);
+            if ($line === '') continue;
+            if (!preg_match('/^(.+?)\s*(eq|neq|contains|starts|empty|not_empty)\s*(.*)$/i', $line, $m)) {
+                continue;
+            }
+            $out[] = ['column' => trim($m[1]), 'op' => strtolower($m[2]), 'value' => trim($m[3])];
+        }
+        return $out;
+    }
+
+    private function parse_mappings(string $raw): array
+    {
+        $decoded = json_decode($raw, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public function render(): void
+    {
+        if (!current_user_can(Plugin::CAPABILITY)) {
+            return;
+        }
+        $s = Settings::all();
+        $updated = !empty($_GET['updated']);
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Excavator Dispatch — Impostazioni', 'excavator-dispatch'); ?></h1>
+            <?php if ($updated): ?>
+                <div class="notice notice-success is-dismissible"><p><?php esc_html_e('Impostazioni salvate.', 'excavator-dispatch'); ?></p></div>
+            <?php endif; ?>
+
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                <input type="hidden" name="action" value="excdis_save_settings" />
+                <?php wp_nonce_field(self::NONCE); ?>
+
+                <h2><?php esc_html_e('Microsoft 365 (Excel via Graph)', 'excavator-dispatch'); ?></h2>
+                <table class="form-table" role="presentation">
+                    <?php $this->row('Tenant ID', 'm365_tenant_id', $s); ?>
+                    <?php $this->row('Client ID', 'm365_client_id', $s); ?>
+                    <?php $this->secret_row('Client Secret', 'm365_client_secret', $s); ?>
+                    <?php $this->row('Drive ID (SharePoint/OneDrive)', 'm365_drive_id', $s); ?>
+                    <?php $this->row('Item ID (opzionale se path)', 'm365_item_id', $s); ?>
+                    <?php $this->row('Path file (alternativa a item id)', 'm365_file_path', $s, 'es: Documenti/Macchine.xlsx'); ?>
+                    <?php $this->row('Worksheet (se non si usa una tabella)', 'm365_worksheet', $s, 'es: Sheet1'); ?>
+                    <?php $this->row('Nome tabella (Excel table, consigliato)', 'm365_table_name', $s); ?>
+                </table>
+
+                <h2><?php esc_html_e('Google Contacts (People API)', 'excavator-dispatch'); ?></h2>
+                <table class="form-table" role="presentation">
+                    <?php $this->secret_textarea('Service account JSON', 'google_service_account_json', $s); ?>
+                    <?php $this->row('Email utente impersonato (domain-wide delegation)', 'google_impersonate_email', $s); ?>
+                    <?php $this->textarea('Contact group resource names (uno per riga)', 'google_group_ids', $s, "es: contactGroups/xxxxxxxxxxxxxxxx"); ?>
+                    <?php $this->row('Prefisso paese default (numeri senza +)', 'default_country_code', $s, 'es: 39'); ?>
+                </table>
+
+                <h2><?php esc_html_e('WhatsApp Cloud API', 'excavator-dispatch'); ?></h2>
+                <table class="form-table" role="presentation">
+                    <?php $this->row('Phone Number ID', 'whatsapp_phone_number_id', $s); ?>
+                    <?php $this->row('WhatsApp Business Account (WABA) ID', 'whatsapp_waba_id', $s); ?>
+                    <?php $this->secret_row('Access Token (long-lived)', 'whatsapp_access_token', $s); ?>
+                    <?php $this->row('Lingua template di default', 'whatsapp_default_language', $s, 'es: it, en_US'); ?>
+                </table>
+
+                <h2><?php esc_html_e('Macchine — colonne e filtri', 'excavator-dispatch'); ?></h2>
+                <table class="form-table" role="presentation">
+                    <?php $this->row('Colonna ID macchina (per selezione stabile)', 'machine_id_column', $s, 'es: Matricola'); ?>
+                    <?php $this->row('Colonne da mostrare in lista (csv)', 'machine_label_columns', $s, 'es: Modello,Anno,Stato', static function ($v): string {
+                        return is_array($v) ? implode(',', $v) : (string) $v;
+                    }); ?>
+                    <?php $this->textarea('Regole filtro (una per riga: "Colonna op valore")', 'machine_filters', $s, "es: Stato eq Disponibile\nFamiglia contains Escavatore", static function ($v): string {
+                        if (!is_array($v)) return '';
+                        $lines = [];
+                        foreach ($v as $r) {
+                            $lines[] = trim(sprintf('%s %s %s', $r['column'] ?? '', $r['op'] ?? 'eq', $r['value'] ?? ''));
+                        }
+                        return implode("\n", $lines);
+                    }); ?>
+                </table>
+
+                <h2><?php esc_html_e('Destinatari — filtri', 'excavator-dispatch'); ?></h2>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row"><label for="excdis_recipients_require_phone"><?php esc_html_e('Solo contatti con numero', 'excavator-dispatch'); ?></label></th>
+                        <td><input type="checkbox" id="excdis_recipients_require_phone" name="excdis[recipients_require_phone]" value="1" <?php checked(!empty($s['recipients_require_phone']) || !isset($s['recipients_require_phone'])); ?> /></td>
+                    </tr>
+                    <?php $this->row('Regex nome (opzionale)', 'recipients_name_regex', $s); ?>
+                </table>
+
+                <h2><?php esc_html_e('Mapping template (JSON)', 'excavator-dispatch'); ?></h2>
+                <p class="description"><?php esc_html_e('Mappa per ogni template Meta le variabili di header/body/footer a espressioni. Espressioni: {col:Colonna}, {list:Col1,Col2}, {count}, oppure testo libero.', 'excavator-dispatch'); ?></p>
+                <?php $this->textarea('JSON', 'template_mappings', $s, '{"avviso_macchine":{"body":["{count}","{list:Modello,Anno}"]}}', static function ($v): string {
+                    return is_array($v) ? (string) wp_json_encode($v, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) : (string) $v;
+                }, 10); ?>
+
+                <p class="submit"><button class="button button-primary"><?php esc_html_e('Salva impostazioni', 'excavator-dispatch'); ?></button></p>
+            </form>
+        </div>
+        <?php
+    }
+
+    private function row(string $label, string $key, array $s, string $placeholder = '', $serializer = null): void
+    {
+        $value = $serializer ? $serializer($s[$key] ?? '') : ($s[$key] ?? '');
+        ?>
+        <tr>
+            <th scope="row"><label for="excdis_<?php echo esc_attr($key); ?>"><?php echo esc_html($label); ?></label></th>
+            <td><input type="text" class="regular-text" id="excdis_<?php echo esc_attr($key); ?>" name="excdis[<?php echo esc_attr($key); ?>]" value="<?php echo esc_attr((string) $value); ?>" placeholder="<?php echo esc_attr($placeholder); ?>" /></td>
+        </tr>
+        <?php
+    }
+
+    private function secret_row(string $label, string $key, array $s): void
+    {
+        $has = !empty($s[$key]);
+        ?>
+        <tr>
+            <th scope="row"><label for="excdis_<?php echo esc_attr($key); ?>"><?php echo esc_html($label); ?></label></th>
+            <td>
+                <input type="password" class="regular-text" id="excdis_<?php echo esc_attr($key); ?>" name="excdis[<?php echo esc_attr($key); ?>]" value="" autocomplete="new-password" placeholder="<?php echo $has ? esc_attr__('(impostato — lascia vuoto per non modificare)', 'excavator-dispatch') : ''; ?>" />
+            </td>
+        </tr>
+        <?php
+    }
+
+    private function textarea(string $label, string $key, array $s, string $placeholder = '', $serializer = null, int $rows = 5): void
+    {
+        $value = $serializer ? $serializer($s[$key] ?? '') : ($s[$key] ?? '');
+        if (is_array($value)) {
+            $value = implode("\n", $value);
+        }
+        ?>
+        <tr>
+            <th scope="row"><label for="excdis_<?php echo esc_attr($key); ?>"><?php echo esc_html($label); ?></label></th>
+            <td><textarea class="large-text code" rows="<?php echo (int) $rows; ?>" id="excdis_<?php echo esc_attr($key); ?>" name="excdis[<?php echo esc_attr($key); ?>]" placeholder="<?php echo esc_attr($placeholder); ?>"><?php echo esc_textarea((string) $value); ?></textarea></td>
+        </tr>
+        <?php
+    }
+
+    private function secret_textarea(string $label, string $key, array $s): void
+    {
+        $has = !empty($s[$key]);
+        ?>
+        <tr>
+            <th scope="row"><label for="excdis_<?php echo esc_attr($key); ?>"><?php echo esc_html($label); ?></label></th>
+            <td>
+                <textarea class="large-text code" rows="6" id="excdis_<?php echo esc_attr($key); ?>" name="excdis[<?php echo esc_attr($key); ?>]" placeholder="<?php echo $has ? esc_attr__('(impostato — lascia vuoto per non modificare)', 'excavator-dispatch') : ''; ?>"></textarea>
+            </td>
+        </tr>
+        <?php
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Integrations/GooglePeopleClient.php
+++ b/public/content/plugins/excavator-dispatch/src/Integrations/GooglePeopleClient.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Integrations;
+
+use InfraSe\ExcavatorDispatch\Support\Cache;
+use InfraSe\ExcavatorDispatch\Support\Settings;
+use RuntimeException;
+
+final class GooglePeopleClient
+{
+    private const TOKEN_TRANSIENT = 'google_token';
+    private const SCOPE = 'https://www.googleapis.com/auth/contacts.readonly';
+    private const API_BASE = 'https://people.googleapis.com/v1';
+
+    public function fetch_contacts(): array
+    {
+        $token = $this->access_token();
+        $contacts = [];
+        $pageToken = null;
+        do {
+            $url = self::API_BASE . '/people/me/connections?personFields=names,emailAddresses,phoneNumbers,memberships,organizations&pageSize=1000';
+            if ($pageToken) {
+                $url .= '&pageToken=' . rawurlencode($pageToken);
+            }
+            $data = $this->google_get($token, $url);
+            foreach ((array) ($data['connections'] ?? []) as $person) {
+                $contacts[] = $this->normalize_person($person);
+            }
+            $pageToken = $data['nextPageToken'] ?? null;
+        } while ($pageToken);
+
+        $contacts = array_merge($contacts, $this->fetch_group_members($token));
+        return $this->deduplicate($contacts);
+    }
+
+    private function fetch_group_members(string $token): array
+    {
+        $groupIds = (array) Settings::get('google_group_ids', []);
+        if (empty($groupIds)) {
+            return [];
+        }
+        $out = [];
+        foreach ($groupIds as $gid) {
+            $gid = trim((string) $gid);
+            if ($gid === '') {
+                continue;
+            }
+            $group = $this->google_get($token, self::API_BASE . '/' . rawurlencode($gid) . '?maxMembers=1000');
+            $memberResourceNames = (array) ($group['memberResourceNames'] ?? []);
+            foreach (array_chunk($memberResourceNames, 50) as $chunk) {
+                $params = '';
+                foreach ($chunk as $rn) {
+                    $params .= '&resourceNames=' . rawurlencode($rn);
+                }
+                $data = $this->google_get($token, self::API_BASE . '/people:batchGet?personFields=names,emailAddresses,phoneNumbers,memberships,organizations' . $params);
+                foreach ((array) ($data['responses'] ?? []) as $entry) {
+                    if (!empty($entry['person'])) {
+                        $out[] = $this->normalize_person($entry['person']);
+                    }
+                }
+            }
+        }
+        return $out;
+    }
+
+    private function deduplicate(array $contacts): array
+    {
+        $seen = [];
+        $out = [];
+        foreach ($contacts as $c) {
+            $key = $c['resource_name'];
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $out[] = $c;
+        }
+        return $out;
+    }
+
+    private function normalize_person(array $p): array
+    {
+        $name = $p['names'][0]['displayName'] ?? '';
+        $email = $p['emailAddresses'][0]['value'] ?? '';
+        $org = $p['organizations'][0]['name'] ?? '';
+
+        $phones = (array) ($p['phoneNumbers'] ?? []);
+        usort($phones, static function (array $a, array $b): int {
+            $ra = ($a['type'] ?? '') === 'mobile' ? 0 : 1;
+            $rb = ($b['type'] ?? '') === 'mobile' ? 0 : 1;
+            return $ra <=> $rb;
+        });
+        $phone = '';
+        foreach ($phones as $ph) {
+            $candidate = (string) ($ph['canonicalForm'] ?? $ph['value'] ?? '');
+            if ($candidate !== '') {
+                $phone = $candidate;
+                break;
+            }
+        }
+
+        $groups = [];
+        foreach ((array) ($p['memberships'] ?? []) as $m) {
+            $gid = $m['contactGroupMembership']['contactGroupResourceName'] ?? null;
+            if ($gid) {
+                $groups[] = (string) $gid;
+            }
+        }
+
+        return [
+            'resource_name' => (string) ($p['resourceName'] ?? ''),
+            'name'          => (string) $name,
+            'email'         => (string) $email,
+            'organization'  => (string) $org,
+            'phone'         => $this->to_e164($phone),
+            'phone_raw'     => $phone,
+            'groups'        => $groups,
+        ];
+    }
+
+    private function to_e164(string $phone): string
+    {
+        $phone = trim($phone);
+        if ($phone === '') {
+            return '';
+        }
+        if (strpos($phone, '+') === 0) {
+            return '+' . preg_replace('/\D+/', '', $phone);
+        }
+        $digits = preg_replace('/\D+/', '', $phone);
+        $default_cc = (string) Settings::get('default_country_code', '');
+        if ($default_cc !== '' && $digits !== '') {
+            return '+' . ltrim($default_cc, '+') . $digits;
+        }
+        return $digits === '' ? '' : '+' . $digits;
+    }
+
+    private function access_token(): string
+    {
+        return Cache::remember(self::TOKEN_TRANSIENT, 3000, function () {
+            $raw = (string) Settings::get('google_service_account_json', '');
+            if ($raw === '') {
+                throw new RuntimeException('Google: service account JSON non configurato.');
+            }
+            $sa = json_decode($raw, true);
+            if (!is_array($sa) || empty($sa['client_email']) || empty($sa['private_key'])) {
+                throw new RuntimeException('Google: JSON service account non valido.');
+            }
+            $subject = (string) Settings::get('google_impersonate_email', '');
+            if ($subject === '') {
+                throw new RuntimeException('Google: impostare l\'email dell\'utente impersonato (domain-wide delegation).');
+            }
+
+            $now = time();
+            $header = ['alg' => 'RS256', 'typ' => 'JWT'];
+            $claims = [
+                'iss'   => $sa['client_email'],
+                'sub'   => $subject,
+                'scope' => self::SCOPE,
+                'aud'   => 'https://oauth2.googleapis.com/token',
+                'exp'   => $now + 3600,
+                'iat'   => $now,
+            ];
+            $segments = [
+                self::b64url(json_encode($header)),
+                self::b64url(json_encode($claims)),
+            ];
+            $signing_input = implode('.', $segments);
+            $signature = '';
+            if (!openssl_sign($signing_input, $signature, $sa['private_key'], OPENSSL_ALGO_SHA256)) {
+                throw new RuntimeException('Google: firma JWT fallita.');
+            }
+            $jwt = $signing_input . '.' . self::b64url($signature);
+
+            $resp = wp_remote_post('https://oauth2.googleapis.com/token', [
+                'timeout' => 20,
+                'body' => [
+                    'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                    'assertion'  => $jwt,
+                ],
+            ]);
+            if (is_wp_error($resp)) {
+                throw new RuntimeException('Google token: ' . $resp->get_error_message());
+            }
+            $data = json_decode((string) wp_remote_retrieve_body($resp), true);
+            if (!is_array($data) || empty($data['access_token'])) {
+                throw new RuntimeException('Google token: risposta non valida.');
+            }
+            return (string) $data['access_token'];
+        });
+    }
+
+    private function google_get(string $token, string $url): array
+    {
+        $resp = wp_remote_get($url, [
+            'timeout' => 20,
+            'headers' => ['Authorization' => 'Bearer ' . $token, 'Accept' => 'application/json'],
+        ]);
+        if (is_wp_error($resp)) {
+            throw new RuntimeException('People GET: ' . $resp->get_error_message());
+        }
+        $code = (int) wp_remote_retrieve_response_code($resp);
+        $body = (string) wp_remote_retrieve_body($resp);
+        if ($code < 200 || $code >= 300) {
+            throw new RuntimeException("People GET {$code}: {$body}");
+        }
+        $data = json_decode($body, true);
+        return is_array($data) ? $data : [];
+    }
+
+    private static function b64url(string $bin): string
+    {
+        return rtrim(strtr(base64_encode($bin), '+/', '-_'), '=');
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Integrations/GraphExcelClient.php
+++ b/public/content/plugins/excavator-dispatch/src/Integrations/GraphExcelClient.php
@@ -61,9 +61,13 @@ final class GraphExcelClient
             if (is_wp_error($resp)) {
                 throw new RuntimeException('Graph token: ' . $resp->get_error_message());
             }
-            $data = json_decode((string) wp_remote_retrieve_body($resp), true);
+            $code = (int) wp_remote_retrieve_response_code($resp);
+            $body = (string) wp_remote_retrieve_body($resp);
+            $data = json_decode($body, true);
             if (!is_array($data) || empty($data['access_token'])) {
-                throw new RuntimeException('Graph token: risposta non valida.');
+                $err = is_array($data) && !empty($data['error']) ? $data['error'] : 'unknown';
+                $desc = is_array($data) && !empty($data['error_description']) ? $data['error_description'] : $body;
+                throw new RuntimeException("Graph token [{$code}] {$err}: {$desc}");
             }
             return (string) $data['access_token'];
         });

--- a/public/content/plugins/excavator-dispatch/src/Integrations/GraphExcelClient.php
+++ b/public/content/plugins/excavator-dispatch/src/Integrations/GraphExcelClient.php
@@ -143,7 +143,8 @@ final class GraphExcelClient
         $code = (int) wp_remote_retrieve_response_code($resp);
         $body = (string) wp_remote_retrieve_body($resp);
         if ($code < 200 || $code >= 300) {
-            throw new RuntimeException("Graph GET {$code}: {$body}");
+            $short_url = preg_replace('#^https://graph\.microsoft\.com/v1\.0#', '', $url);
+            throw new RuntimeException("Graph GET {$code} on {$short_url} :: {$body}");
         }
         $data = json_decode($body, true);
         return is_array($data) ? $data : [];

--- a/public/content/plugins/excavator-dispatch/src/Integrations/GraphExcelClient.php
+++ b/public/content/plugins/excavator-dispatch/src/Integrations/GraphExcelClient.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Integrations;
+
+use InfraSe\ExcavatorDispatch\Support\Cache;
+use InfraSe\ExcavatorDispatch\Support\Settings;
+use RuntimeException;
+
+final class GraphExcelClient
+{
+    private const TOKEN_TRANSIENT = 'graph_token';
+    private const GRAPH_BASE = 'https://graph.microsoft.com/v1.0';
+
+    public function fetch_rows(): array
+    {
+        $s = Settings::all();
+        foreach (['m365_tenant_id', 'm365_client_id', 'm365_client_secret'] as $req) {
+            if (empty($s[$req])) {
+                throw new RuntimeException("Microsoft 365: '{$req}' non configurato.");
+            }
+        }
+        $drive_id = (string) ($s['m365_drive_id'] ?? '');
+        $item_id  = (string) ($s['m365_item_id'] ?? '');
+        $file_path = (string) ($s['m365_file_path'] ?? '');
+        $worksheet = (string) ($s['m365_worksheet'] ?? 'Sheet1');
+        $table_name = (string) ($s['m365_table_name'] ?? '');
+
+        if ($drive_id === '' || ($item_id === '' && $file_path === '')) {
+            throw new RuntimeException('Configurare drive_id e (item_id o file_path) per il file Excel.');
+        }
+
+        $token = $this->access_token();
+
+        if ($item_id === '') {
+            $item_id = $this->resolve_item_id($token, $drive_id, $file_path);
+        }
+
+        if ($table_name !== '') {
+            $url = self::GRAPH_BASE . "/drives/{$drive_id}/items/{$item_id}/workbook/tables/" . rawurlencode($table_name) . '/rows?$top=999';
+            return $this->fetch_table_rows($token, $url, $table_name, $drive_id, $item_id);
+        }
+
+        return $this->fetch_used_range($token, $drive_id, $item_id, $worksheet);
+    }
+
+    private function access_token(): string
+    {
+        return Cache::remember(self::TOKEN_TRANSIENT, 3000, function () {
+            $s = Settings::all();
+            $resp = wp_remote_post("https://login.microsoftonline.com/{$s['m365_tenant_id']}/oauth2/v2.0/token", [
+                'timeout' => 20,
+                'body' => [
+                    'client_id'     => $s['m365_client_id'],
+                    'client_secret' => $s['m365_client_secret'],
+                    'grant_type'    => 'client_credentials',
+                    'scope'         => 'https://graph.microsoft.com/.default',
+                ],
+            ]);
+            if (is_wp_error($resp)) {
+                throw new RuntimeException('Graph token: ' . $resp->get_error_message());
+            }
+            $data = json_decode((string) wp_remote_retrieve_body($resp), true);
+            if (!is_array($data) || empty($data['access_token'])) {
+                throw new RuntimeException('Graph token: risposta non valida.');
+            }
+            return (string) $data['access_token'];
+        });
+    }
+
+    private function resolve_item_id(string $token, string $drive_id, string $path): string
+    {
+        $path = ltrim($path, '/');
+        $url = self::GRAPH_BASE . "/drives/{$drive_id}/root:/" . rawurlencode($path) . ':';
+        // rawurlencode encodes slashes too; restore them for path segments.
+        $url = str_replace('%2F', '/', $url);
+        $data = $this->graph_get($token, $url);
+        if (empty($data['id'])) {
+            throw new RuntimeException('Graph: file non trovato al percorso ' . $path);
+        }
+        return (string) $data['id'];
+    }
+
+    private function fetch_table_rows(string $token, string $url, string $table, string $drive_id, string $item_id): array
+    {
+        $headers = $this->fetch_table_headers($token, $drive_id, $item_id, $table);
+        $data = $this->graph_get($token, $url);
+        $rows = [];
+        foreach ((array) ($data['value'] ?? []) as $i => $entry) {
+            $values = $entry['values'][0] ?? [];
+            $assoc = [];
+            foreach ($headers as $col => $header) {
+                $assoc[$header] = $values[$col] ?? null;
+            }
+            $assoc['__row'] = $i;
+            $rows[] = $assoc;
+        }
+        return $rows;
+    }
+
+    private function fetch_table_headers(string $token, string $drive_id, string $item_id, string $table): array
+    {
+        $url = self::GRAPH_BASE . "/drives/{$drive_id}/items/{$item_id}/workbook/tables/" . rawurlencode($table) . '/headerRowRange';
+        $data = $this->graph_get($token, $url);
+        return (array) ($data['values'][0] ?? []);
+    }
+
+    private function fetch_used_range(string $token, string $drive_id, string $item_id, string $worksheet): array
+    {
+        $url = self::GRAPH_BASE . "/drives/{$drive_id}/items/{$item_id}/workbook/worksheets('" . rawurlencode($worksheet) . "')/usedRange";
+        $data = $this->graph_get($token, $url);
+        $values = (array) ($data['values'] ?? []);
+        if (empty($values)) {
+            return [];
+        }
+        $headers = array_map('strval', array_shift($values));
+        $rows = [];
+        foreach ($values as $i => $line) {
+            $assoc = [];
+            foreach ($headers as $col => $header) {
+                $assoc[$header] = $line[$col] ?? null;
+            }
+            $assoc['__row'] = $i;
+            $rows[] = $assoc;
+        }
+        return $rows;
+    }
+
+    private function graph_get(string $token, string $url): array
+    {
+        $resp = wp_remote_get($url, [
+            'timeout' => 20,
+            'headers' => ['Authorization' => 'Bearer ' . $token, 'Accept' => 'application/json'],
+        ]);
+        if (is_wp_error($resp)) {
+            throw new RuntimeException('Graph GET: ' . $resp->get_error_message());
+        }
+        $code = (int) wp_remote_retrieve_response_code($resp);
+        $body = (string) wp_remote_retrieve_body($resp);
+        if ($code < 200 || $code >= 300) {
+            throw new RuntimeException("Graph GET {$code}: {$body}");
+        }
+        $data = json_decode($body, true);
+        return is_array($data) ? $data : [];
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Integrations/WhatsAppCloudClient.php
+++ b/public/content/plugins/excavator-dispatch/src/Integrations/WhatsAppCloudClient.php
@@ -79,7 +79,12 @@ final class WhatsAppCloudClient
         $body = (string) wp_remote_retrieve_body($resp);
         $data = json_decode($body, true);
         if ($code < 200 || $code >= 300) {
-            $msg = $data['error']['message'] ?? $body;
+            $err = $data['error'] ?? [];
+            $msg = (string) ($err['message'] ?? $body);
+            $details = (string) ($err['error_data']['details'] ?? '');
+            if ($details !== '') {
+                $msg .= ' — ' . $details;
+            }
             throw new RuntimeException("WhatsApp {$code}: {$msg}");
         }
         return is_array($data) ? $data : [];

--- a/public/content/plugins/excavator-dispatch/src/Integrations/WhatsAppCloudClient.php
+++ b/public/content/plugins/excavator-dispatch/src/Integrations/WhatsAppCloudClient.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Integrations;
+
+use InfraSe\ExcavatorDispatch\Support\Settings;
+use RuntimeException;
+
+final class WhatsAppCloudClient
+{
+    private const API_VERSION = 'v20.0';
+    private const API_BASE = 'https://graph.facebook.com';
+
+    public function list_templates(): array
+    {
+        $waba_id = (string) Settings::get('whatsapp_waba_id', '');
+        if ($waba_id === '') {
+            throw new RuntimeException('WhatsApp: WABA ID non configurato.');
+        }
+        $token = (string) Settings::get('whatsapp_access_token', '');
+        $url = self::API_BASE . '/' . self::API_VERSION . '/' . rawurlencode($waba_id) . '/message_templates?fields=name,status,language,category,components&limit=200';
+        $out = [];
+        while ($url) {
+            $data = $this->graph_get($token, $url);
+            foreach ((array) ($data['data'] ?? []) as $t) {
+                if (($t['status'] ?? '') !== 'APPROVED') {
+                    continue;
+                }
+                $out[] = [
+                    'name'       => (string) ($t['name'] ?? ''),
+                    'language'   => (string) ($t['language'] ?? ''),
+                    'category'   => (string) ($t['category'] ?? ''),
+                    'components' => $t['components'] ?? [],
+                ];
+            }
+            $url = $data['paging']['next'] ?? null;
+        }
+        return $out;
+    }
+
+    /**
+     * Send a template message.
+     *
+     * @param array<int, array{type: string, parameters: array}> $components
+     */
+    public function send_template(string $to, string $template_name, string $language, array $components = []): array
+    {
+        $phone_id = (string) Settings::get('whatsapp_phone_number_id', '');
+        $token = (string) Settings::get('whatsapp_access_token', '');
+        if ($phone_id === '' || $token === '') {
+            throw new RuntimeException('WhatsApp: phone number ID o token mancanti.');
+        }
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'to'                => $to,
+            'type'              => 'template',
+            'template'          => [
+                'name'     => $template_name,
+                'language' => ['code' => $language],
+            ],
+        ];
+        if (!empty($components)) {
+            $payload['template']['components'] = array_values($components);
+        }
+
+        $resp = wp_remote_post(self::API_BASE . '/' . self::API_VERSION . '/' . rawurlencode($phone_id) . '/messages', [
+            'timeout' => 20,
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'Content-Type'  => 'application/json',
+            ],
+            'body' => wp_json_encode($payload),
+        ]);
+        if (is_wp_error($resp)) {
+            throw new RuntimeException('WhatsApp: ' . $resp->get_error_message());
+        }
+        $code = (int) wp_remote_retrieve_response_code($resp);
+        $body = (string) wp_remote_retrieve_body($resp);
+        $data = json_decode($body, true);
+        if ($code < 200 || $code >= 300) {
+            $msg = $data['error']['message'] ?? $body;
+            throw new RuntimeException("WhatsApp {$code}: {$msg}");
+        }
+        return is_array($data) ? $data : [];
+    }
+
+    private function graph_get(string $token, string $url): array
+    {
+        $resp = wp_remote_get($url, [
+            'timeout' => 20,
+            'headers' => ['Authorization' => 'Bearer ' . $token, 'Accept' => 'application/json'],
+        ]);
+        if (is_wp_error($resp)) {
+            throw new RuntimeException('WhatsApp GET: ' . $resp->get_error_message());
+        }
+        $code = (int) wp_remote_retrieve_response_code($resp);
+        $body = (string) wp_remote_retrieve_body($resp);
+        if ($code < 200 || $code >= 300) {
+            throw new RuntimeException("WhatsApp GET {$code}: {$body}");
+        }
+        $data = json_decode($body, true);
+        return is_array($data) ? $data : [];
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Plugin.php
+++ b/public/content/plugins/excavator-dispatch/src/Plugin.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch;
+
+use InfraSe\ExcavatorDispatch\Admin\DispatchPage;
+use InfraSe\ExcavatorDispatch\Admin\LogPage;
+use InfraSe\ExcavatorDispatch\Admin\SettingsPage;
+use InfraSe\ExcavatorDispatch\Rest\DispatchController;
+use InfraSe\ExcavatorDispatch\Rest\MachinesController;
+use InfraSe\ExcavatorDispatch\Rest\RecipientsController;
+use InfraSe\ExcavatorDispatch\Rest\TemplatesController;
+use InfraSe\ExcavatorDispatch\Support\Logger;
+
+final class Plugin
+{
+    public const CAPABILITY = 'manage_options';
+    public const MENU_SLUG  = 'excavator-dispatch';
+    public const REST_NS    = 'excavator-dispatch/v1';
+
+    private static ?Plugin $instance = null;
+
+    public static function instance(): Plugin
+    {
+        return self::$instance ??= new self();
+    }
+
+    public function boot(): void
+    {
+        load_plugin_textdomain('excavator-dispatch', false, dirname(plugin_basename(EXCDIS_FILE)) . '/languages');
+
+        (new SettingsPage())->register();
+        (new DispatchPage())->register();
+        (new LogPage())->register();
+
+        add_action('rest_api_init', function (): void {
+            (new MachinesController())->register_routes();
+            (new RecipientsController())->register_routes();
+            (new TemplatesController())->register_routes();
+            (new DispatchController())->register_routes();
+        });
+    }
+
+    public static function activate(): void
+    {
+        Logger::install_table();
+        if (!get_option('excdis_settings')) {
+            add_option('excdis_settings', []);
+        }
+    }
+
+    public static function deactivate(): void
+    {
+        // Keep settings + log table on deactivation; uninstall.php would handle removal.
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Rest/DispatchController.php
+++ b/public/content/plugins/excavator-dispatch/src/Rest/DispatchController.php
@@ -60,7 +60,7 @@ final class DispatchController
                 return new WP_Error('excdis_no_machines', 'Nessuna macchina selezionata corrisponde ai dati correnti.', ['status' => 400]);
             }
 
-            $components = (new TemplateRenderer())->build_components($template, $selected);
+            $renderer = new TemplateRenderer();
             $client = new WhatsAppCloudClient();
 
             $details = [];
@@ -74,6 +74,12 @@ final class DispatchController
                     $details[] = ['name' => $name, 'phone' => '', 'ok' => false, 'error' => 'Numero non valido'];
                     continue;
                 }
+                $recipient_ctx = [
+                    'name'         => $name,
+                    'phone'        => $to,
+                    'organization' => (string) ($r['organization'] ?? ''),
+                ];
+                $components = $renderer->build_components($template, $selected, $recipient_ctx);
                 try {
                     $resp = $client->send_template($to, $template, $language, $components);
                     $msg_id = $resp['messages'][0]['id'] ?? '';

--- a/public/content/plugins/excavator-dispatch/src/Rest/DispatchController.php
+++ b/public/content/plugins/excavator-dispatch/src/Rest/DispatchController.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Rest;
+
+use InfraSe\ExcavatorDispatch\Integrations\GraphExcelClient;
+use InfraSe\ExcavatorDispatch\Integrations\WhatsAppCloudClient;
+use InfraSe\ExcavatorDispatch\Plugin;
+use InfraSe\ExcavatorDispatch\Services\MachineFilter;
+use InfraSe\ExcavatorDispatch\Services\TemplateRenderer;
+use InfraSe\ExcavatorDispatch\Support\Cache;
+use InfraSe\ExcavatorDispatch\Support\Logger;
+use InfraSe\ExcavatorDispatch\Support\Settings;
+use Throwable;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class DispatchController
+{
+    public function register_routes(): void
+    {
+        register_rest_route(Plugin::REST_NS, '/dispatch', [
+            'methods'             => 'POST',
+            'permission_callback' => [$this, 'can_access'],
+            'callback'            => [$this, 'dispatch'],
+            'args'                => [
+                'template'    => ['type' => 'string', 'required' => true],
+                'machine_ids' => ['type' => 'array', 'required' => true],
+                'recipients'  => ['type' => 'array', 'required' => true],
+            ],
+        ]);
+    }
+
+    public function can_access(): bool
+    {
+        return current_user_can(Plugin::CAPABILITY);
+    }
+
+    public function dispatch(WP_REST_Request $request)
+    {
+        $template = sanitize_text_field((string) $request->get_param('template'));
+        $machine_ids = array_map('strval', (array) $request->get_param('machine_ids'));
+        $recipients_raw = (array) $request->get_param('recipients');
+
+        if ($template === '' || empty($machine_ids) || empty($recipients_raw)) {
+            return new WP_Error('excdis_invalid', 'Template, macchine e destinatari sono richiesti.', ['status' => 400]);
+        }
+
+        $language = (string) Settings::get('whatsapp_default_language', 'it');
+
+        try {
+            $rows = Cache::remember('machines_rows', Cache::TTL_DEFAULT, static function () {
+                return (new GraphExcelClient())->fetch_rows();
+            });
+            $rows = (new MachineFilter())->apply($rows);
+            $selected = $this->select_rows($rows, $machine_ids);
+            if (empty($selected)) {
+                return new WP_Error('excdis_no_machines', 'Nessuna macchina selezionata corrisponde ai dati correnti.', ['status' => 400]);
+            }
+
+            $components = (new TemplateRenderer())->build_components($template, $selected);
+            $client = new WhatsAppCloudClient();
+
+            $details = [];
+            $success = 0;
+            $errors  = 0;
+            foreach ($recipients_raw as $r) {
+                $to = $this->normalize_phone((string) ($r['phone'] ?? $r));
+                $name = (string) ($r['name'] ?? '');
+                if ($to === '') {
+                    $errors++;
+                    $details[] = ['name' => $name, 'phone' => '', 'ok' => false, 'error' => 'Numero non valido'];
+                    continue;
+                }
+                try {
+                    $resp = $client->send_template($to, $template, $language, $components);
+                    $msg_id = $resp['messages'][0]['id'] ?? '';
+                    $success++;
+                    $details[] = ['name' => $name, 'phone' => $to, 'ok' => true, 'message_id' => $msg_id];
+                } catch (Throwable $e) {
+                    $errors++;
+                    $details[] = ['name' => $name, 'phone' => $to, 'ok' => false, 'error' => $e->getMessage()];
+                }
+                usleep(50000); // ~20 msg/s soft throttle.
+            }
+
+            Logger::record([
+                'template_name'     => $template,
+                'template_language' => $language,
+                'machine_count'     => count($selected),
+                'recipient_count'   => count($recipients_raw),
+                'success_count'     => $success,
+                'error_count'       => $errors,
+                'details'           => [
+                    'machines' => $selected,
+                    'results'  => $details,
+                ],
+            ]);
+
+            return new WP_REST_Response([
+                'success'   => $success,
+                'errors'    => $errors,
+                'total'     => count($recipients_raw),
+                'machines'  => count($selected),
+                'results'   => $details,
+            ]);
+        } catch (Throwable $e) {
+            return new WP_Error('excdis_dispatch_error', $e->getMessage(), ['status' => 502]);
+        }
+    }
+
+    private function select_rows(array $rows, array $ids): array
+    {
+        $id_col = (string) Settings::get('machine_id_column', '');
+        $out = [];
+        $ids_map = array_flip($ids);
+        foreach ($rows as $row) {
+            $row_id = $id_col !== ''
+                ? (string) ($row[$id_col] ?? '')
+                : (string) ($row['__row'] ?? '');
+            if ($row_id !== '' && isset($ids_map[$row_id])) {
+                $out[] = $row;
+            }
+        }
+        return $out;
+    }
+
+    private function normalize_phone(string $phone): string
+    {
+        $phone = trim($phone);
+        if ($phone === '') {
+            return '';
+        }
+        // WhatsApp Cloud API wants E.164 without the leading '+'.
+        $digits = preg_replace('/\D+/', '', $phone);
+        return $digits ?: '';
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Rest/MachinesController.php
+++ b/public/content/plugins/excavator-dispatch/src/Rest/MachinesController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Rest;
+
+use InfraSe\ExcavatorDispatch\Integrations\GraphExcelClient;
+use InfraSe\ExcavatorDispatch\Plugin;
+use InfraSe\ExcavatorDispatch\Services\MachineFilter;
+use InfraSe\ExcavatorDispatch\Support\Cache;
+use Throwable;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class MachinesController
+{
+    public function register_routes(): void
+    {
+        register_rest_route(Plugin::REST_NS, '/machines', [
+            'methods'             => 'GET',
+            'permission_callback' => [$this, 'can_access'],
+            'callback'            => [$this, 'index'],
+            'args'                => [
+                'refresh' => ['type' => 'boolean', 'default' => false],
+            ],
+        ]);
+    }
+
+    public function can_access(): bool
+    {
+        return current_user_can(Plugin::CAPABILITY);
+    }
+
+    public function index(WP_REST_Request $request)
+    {
+        if ($request->get_param('refresh')) {
+            Cache::forget('machines_rows');
+        }
+        try {
+            $rows = Cache::remember('machines_rows', Cache::TTL_DEFAULT, static function () {
+                return (new GraphExcelClient())->fetch_rows();
+            });
+            $filtered = (new MachineFilter())->apply($rows);
+            return new WP_REST_Response([
+                'count'    => count($filtered),
+                'total'    => count($rows),
+                'machines' => $filtered,
+            ]);
+        } catch (Throwable $e) {
+            return new WP_Error('excdis_machines_error', $e->getMessage(), ['status' => 502]);
+        }
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Rest/RecipientsController.php
+++ b/public/content/plugins/excavator-dispatch/src/Rest/RecipientsController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Rest;
+
+use InfraSe\ExcavatorDispatch\Integrations\GooglePeopleClient;
+use InfraSe\ExcavatorDispatch\Plugin;
+use InfraSe\ExcavatorDispatch\Services\RecipientFilter;
+use InfraSe\ExcavatorDispatch\Support\Cache;
+use Throwable;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class RecipientsController
+{
+    public function register_routes(): void
+    {
+        register_rest_route(Plugin::REST_NS, '/recipients', [
+            'methods'             => 'GET',
+            'permission_callback' => [$this, 'can_access'],
+            'callback'            => [$this, 'index'],
+            'args'                => [
+                'refresh' => ['type' => 'boolean', 'default' => false],
+            ],
+        ]);
+    }
+
+    public function can_access(): bool
+    {
+        return current_user_can(Plugin::CAPABILITY);
+    }
+
+    public function index(WP_REST_Request $request)
+    {
+        if ($request->get_param('refresh')) {
+            Cache::forget('recipients_contacts');
+        }
+        try {
+            $contacts = Cache::remember('recipients_contacts', Cache::TTL_DEFAULT, static function () {
+                return (new GooglePeopleClient())->fetch_contacts();
+            });
+            $filtered = (new RecipientFilter())->apply($contacts);
+            return new WP_REST_Response([
+                'count'      => count($filtered),
+                'total'      => count($contacts),
+                'recipients' => $filtered,
+            ]);
+        } catch (Throwable $e) {
+            return new WP_Error('excdis_recipients_error', $e->getMessage(), ['status' => 502]);
+        }
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Rest/TemplatesController.php
+++ b/public/content/plugins/excavator-dispatch/src/Rest/TemplatesController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Rest;
+
+use InfraSe\ExcavatorDispatch\Integrations\WhatsAppCloudClient;
+use InfraSe\ExcavatorDispatch\Plugin;
+use InfraSe\ExcavatorDispatch\Support\Cache;
+use InfraSe\ExcavatorDispatch\Support\Settings;
+use Throwable;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class TemplatesController
+{
+    public function register_routes(): void
+    {
+        register_rest_route(Plugin::REST_NS, '/templates', [
+            'methods'             => 'GET',
+            'permission_callback' => [$this, 'can_access'],
+            'callback'            => [$this, 'index'],
+            'args'                => [
+                'refresh' => ['type' => 'boolean', 'default' => false],
+            ],
+        ]);
+    }
+
+    public function can_access(): bool
+    {
+        return current_user_can(Plugin::CAPABILITY);
+    }
+
+    public function index(WP_REST_Request $request)
+    {
+        if ($request->get_param('refresh')) {
+            Cache::forget('whatsapp_templates');
+        }
+        $language = (string) Settings::get('whatsapp_default_language', 'it');
+        try {
+            $templates = Cache::remember('whatsapp_templates', 600, static function () {
+                return (new WhatsAppCloudClient())->list_templates();
+            });
+            $filtered = array_values(array_filter($templates, static function (array $t) use ($language): bool {
+                return $language === '' || ($t['language'] ?? '') === $language;
+            }));
+            return new WP_REST_Response([
+                'language'  => $language,
+                'count'     => count($filtered),
+                'templates' => $filtered,
+            ]);
+        } catch (Throwable $e) {
+            return new WP_Error('excdis_templates_error', $e->getMessage(), ['status' => 502]);
+        }
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Services/MachineFilter.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/MachineFilter.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Services;
+
+use InfraSe\ExcavatorDispatch\Support\Settings;
+
+final class MachineFilter
+{
+    public function apply(array $rows): array
+    {
+        $rules = (array) Settings::get('machine_filters', []);
+        if (empty($rules)) {
+            return array_values($rows);
+        }
+        $out = [];
+        foreach ($rows as $row) {
+            if ($this->matches($row, $rules)) {
+                $out[] = $row;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * @param array<int, array{column: string, op: string, value: string}> $rules
+     */
+    private function matches(array $row, array $rules): bool
+    {
+        foreach ($rules as $rule) {
+            $col = (string) ($rule['column'] ?? '');
+            $op  = (string) ($rule['op'] ?? 'eq');
+            $val = (string) ($rule['value'] ?? '');
+            if ($col === '') {
+                continue;
+            }
+            $cell = (string) ($row[$col] ?? '');
+            if (!$this->compare($cell, $op, $val)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function compare(string $cell, string $op, string $value): bool
+    {
+        $cellLc = mb_strtolower($cell);
+        $valLc  = mb_strtolower($value);
+        switch ($op) {
+            case 'eq':       return $cellLc === $valLc;
+            case 'neq':      return $cellLc !== $valLc;
+            case 'contains': return $valLc === '' || strpos($cellLc, $valLc) !== false;
+            case 'starts':   return $valLc === '' || strpos($cellLc, $valLc) === 0;
+            case 'not_empty':return $cell !== '';
+            case 'empty':    return $cell === '';
+            default:         return false;
+        }
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Services/RecipientFilter.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/RecipientFilter.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Services;
+
+use InfraSe\ExcavatorDispatch\Support\Settings;
+
+final class RecipientFilter
+{
+    public function apply(array $contacts): array
+    {
+        $require_phone = (bool) Settings::get('recipients_require_phone', true);
+        $name_regex    = (string) Settings::get('recipients_name_regex', '');
+        $only_groups   = (array) Settings::get('google_group_ids', []);
+        $only_groups   = array_filter(array_map('strval', $only_groups));
+
+        $out = [];
+        foreach ($contacts as $c) {
+            if ($require_phone && empty($c['phone'])) {
+                continue;
+            }
+            if ($name_regex !== '' && @preg_match('/' . $name_regex . '/u', (string) ($c['name'] ?? '')) !== 1) {
+                continue;
+            }
+            if (!empty($only_groups)) {
+                $intersection = array_intersect($only_groups, (array) ($c['groups'] ?? []));
+                if (empty($intersection)) {
+                    continue;
+                }
+            }
+            $out[] = $c;
+        }
+        return $out;
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
@@ -16,6 +16,8 @@ use InfraSe\ExcavatorDispatch\Support\Settings;
  *
  * Expressions supported in any value:
  *   {col:Name}         first machine's "Name" column
+ *   {at:N,Col1,Col2}   N-th machine (0-based), joins given columns with space
+ *                      returns "—" when no machine at that index
  *   {list:Col1,Col2}   inline list joined by ' · '
  *   {bullets:Col1,Col2} inline list joined by ' • '
  *   {count}            number of selected machines
@@ -90,6 +92,22 @@ final class TemplateRenderer
         $expression = preg_replace_callback('/\{col:([^}]+)\}/u', static function (array $m) use ($machines): string {
             $col = trim($m[1]);
             return (string) ($machines[0][$col] ?? '');
+        }, $expression) ?? $expression;
+
+        $expression = preg_replace_callback('/\{at:(\d+),([^}]+)\}/u', static function (array $m) use ($machines): string {
+            $idx = (int) $m[1];
+            if (!isset($machines[$idx])) {
+                return '—';
+            }
+            $cols = array_map('trim', explode(',', $m[2]));
+            $parts = [];
+            foreach ($cols as $c) {
+                $v = trim((string) ($machines[$idx][$c] ?? ''));
+                if ($v !== '') {
+                    $parts[] = $v;
+                }
+            }
+            return $parts === [] ? '—' : implode(' ', $parts);
         }, $expression) ?? $expression;
 
         $expression = preg_replace_callback('/\{list:([^}]+)\}/u', static function (array $m) use ($machines): string {

--- a/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
@@ -60,6 +60,13 @@ final class TemplateRenderer
             if (empty($config[$type]) || !is_array($config[$type])) {
                 continue;
             }
+            if ($type === 'header' && $this->is_media_header($config[$type])) {
+                $media = $this->build_media_header($config[$type], $machines, $recipient);
+                if ($media !== null) {
+                    $components[] = $media;
+                }
+                continue;
+            }
             $is_named = $this->is_assoc($config[$type]);
             $params = [];
             foreach ($config[$type] as $key => $expr) {
@@ -88,6 +95,37 @@ final class TemplateRenderer
         }
 
         return $components;
+    }
+
+    private function is_media_header(array $cfg): bool
+    {
+        foreach (['image', 'video', 'document'] as $k) {
+            if (array_key_exists($k, $cfg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function build_media_header(array $cfg, array $machines, array $recipient): ?array
+    {
+        foreach (['image', 'video', 'document'] as $kind) {
+            if (empty($cfg[$kind])) {
+                continue;
+            }
+            $link = trim($this->evaluate((string) $cfg[$kind], $machines, $recipient));
+            if ($link === '') {
+                return null;
+            }
+            return [
+                'type'       => 'header',
+                'parameters' => [[
+                    'type' => $kind,
+                    $kind  => ['link' => $link],
+                ]],
+            ];
+        }
+        return null;
     }
 
     private function build_carousel(array $cfg, array $machines, array $recipient): ?array

--- a/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
@@ -9,18 +9,23 @@ use InfraSe\ExcavatorDispatch\Support\Settings;
 /**
  * Builds the components[] payload for a WhatsApp template call.
  *
- * The mapping configured in settings ties each template variable to an
- * expression that is evaluated against the list of selected machines.
+ * Mapping shape per template:
+ *   "header"/"body"/"footer": either
+ *     - sequential array of expressions   -> positional {{1}}, {{2}}, ...
+ *     - associative array name=>expression -> named {{name}} placeholders
  *
- * Supported expressions:
- *  - {col:Name}                  -> first machine's "Name" column
- *  - {list:Modello,Anno}         -> bullet list joining the given columns for every selected machine
- *  - {count}                     -> number of selected machines
- *  - literal text                -> used as-is
+ * Expressions supported in any value:
+ *   {col:Name}         first machine's "Name" column
+ *   {list:Col1,Col2}   bullet list joining the columns for every machine
+ *   {count}            number of selected machines
+ *   {recipient_name}   contact display name
+ *   {recipient_phone}  contact phone (E.164)
+ *   {recipient_org}    contact organization
+ *   literal text       used as-is
  */
 final class TemplateRenderer
 {
-    public function build_components(string $template_name, array $machines): array
+    public function build_components(string $template_name, array $machines, array $recipient = []): array
     {
         $mappings = (array) Settings::get('template_mappings', []);
         $config = $mappings[$template_name] ?? null;
@@ -34,12 +39,17 @@ final class TemplateRenderer
             if (empty($config[$type]) || !is_array($config[$type])) {
                 continue;
             }
+            $is_named = $this->is_assoc($config[$type]);
             $params = [];
-            foreach ($config[$type] as $expr) {
-                $params[] = [
+            foreach ($config[$type] as $key => $expr) {
+                $param = [
                     'type' => 'text',
-                    'text' => $this->evaluate((string) $expr, $machines),
+                    'text' => $this->evaluate((string) $expr, $machines, $recipient),
                 ];
+                if ($is_named) {
+                    $param['parameter_name'] = (string) $key;
+                }
+                $params[] = $param;
             }
             if (!empty($params)) {
                 $components[] = [
@@ -51,11 +61,24 @@ final class TemplateRenderer
         return $components;
     }
 
-    public function evaluate(string $expression, array $machines): string
+    public function evaluate(string $expression, array $machines, array $recipient = []): string
     {
         $expression = (string) $expression;
+
         $expression = preg_replace_callback('/\{count\}/', static function () use ($machines): string {
             return (string) count($machines);
+        }, $expression) ?? $expression;
+
+        $expression = preg_replace_callback('/\{recipient_name\}/u', static function () use ($recipient): string {
+            return (string) ($recipient['name'] ?? '');
+        }, $expression) ?? $expression;
+
+        $expression = preg_replace_callback('/\{recipient_phone\}/u', static function () use ($recipient): string {
+            return (string) ($recipient['phone'] ?? '');
+        }, $expression) ?? $expression;
+
+        $expression = preg_replace_callback('/\{recipient_org\}/u', static function () use ($recipient): string {
+            return (string) ($recipient['organization'] ?? '');
         }, $expression) ?? $expression;
 
         $expression = preg_replace_callback('/\{col:([^}]+)\}/u', static function (array $m) use ($machines): string {
@@ -82,5 +105,13 @@ final class TemplateRenderer
         }, $expression) ?? $expression;
 
         return $expression;
+    }
+
+    private function is_assoc(array $arr): bool
+    {
+        if ($arr === []) {
+            return false;
+        }
+        return array_keys($arr) !== range(0, count($arr) - 1);
     }
 }

--- a/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
@@ -87,6 +87,12 @@ final class TemplateRenderer
             }
         }
 
+        if (!empty($config['buttons']) && is_array($config['buttons'])) {
+            foreach ($this->build_buttons($config['buttons'], $machines, $recipient) as $btn) {
+                $components[] = $btn;
+            }
+        }
+
         if (!empty($config['carousel']) && is_array($config['carousel'])) {
             $carousel = $this->build_carousel($config['carousel'], $machines, $recipient);
             if ($carousel !== null) {
@@ -105,6 +111,51 @@ final class TemplateRenderer
             }
         }
         return false;
+    }
+
+    /**
+     * Builds button components for a non-carousel template.
+     *
+     * Each button entry shape:
+     *   { "sub_type": "url"|"quick_reply"|"copy_code", "param": "...", "index": 0 }
+     *
+     * Static buttons (URL without variable, Phone, plain Quick Reply) don't
+     * need an entry here — Meta resolves them from the template definition.
+     */
+    private function build_buttons(array $buttons, array $machines, array $recipient): array
+    {
+        $out = [];
+        $auto_index = 0;
+        foreach ($buttons as $key => $btn) {
+            if (!is_array($btn) || empty($btn['sub_type'])) {
+                $auto_index++;
+                continue;
+            }
+            $sub = (string) $btn['sub_type'];
+            $index = isset($btn['index']) ? (int) $btn['index'] : (is_int($key) ? $key : $auto_index);
+            $value = self::sanitize_param($this->evaluate((string) ($btn['param'] ?? ''), $machines, $recipient));
+
+            switch ($sub) {
+                case 'quick_reply':
+                    $param = ['type' => 'payload', 'payload' => $value];
+                    break;
+                case 'copy_code':
+                    $param = ['type' => 'coupon_code', 'coupon_code' => $value];
+                    break;
+                case 'url':
+                default:
+                    $param = ['type' => 'text', 'text' => $value];
+                    break;
+            }
+            $out[] = [
+                'type'       => 'button',
+                'sub_type'   => $sub,
+                'index'      => (string) $index,
+                'parameters' => [$param],
+            ];
+            $auto_index++;
+        }
+        return $out;
     }
 
     private function build_media_header(array $cfg, array $machines, array $recipient): ?array

--- a/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
@@ -20,11 +20,24 @@ use InfraSe\ExcavatorDispatch\Support\Settings;
  *                      returns "—" when no machine at that index
  *   {list:Col1,Col2}   inline list joined by ' · '
  *   {bullets:Col1,Col2} inline list joined by ' • '
+ *   {img:Column}       composes a full URL from the "Image URL pattern"
+ *                      setting (placeholder {value}) and the column value
  *   {count}            number of selected machines
  *   {recipient_name}   contact display name
  *   {recipient_phone}  contact phone (E.164)
  *   {recipient_org}    contact organization
  *   literal text       used as-is
+ *
+ * Carousel templates: add a "carousel" key alongside body/header/footer:
+ *   "carousel": {
+ *     "header_image": "{img:Foto}",          // header image link expression
+ *     "body": { "name": "{col:Modello}" },   // per-card body params
+ *     "buttons": [                            // optional, max 2 per card
+ *        { "sub_type": "url",         "param": "{col:Matricola}" },
+ *        { "sub_type": "quick_reply", "param": "interested-{col:Matricola}" }
+ *     ],
+ *     "max_cards": 10                         // optional, hard cap 10
+ *   }
  *
  * NOTE: WhatsApp Cloud API rejects parameters containing newlines, tabs,
  * or 5+ consecutive spaces. Vertical bulleted lists are not possible
@@ -66,7 +79,89 @@ final class TemplateRenderer
                 ];
             }
         }
+
+        if (!empty($config['carousel']) && is_array($config['carousel'])) {
+            $carousel = $this->build_carousel($config['carousel'], $machines, $recipient);
+            if ($carousel !== null) {
+                $components[] = $carousel;
+            }
+        }
+
         return $components;
+    }
+
+    private function build_carousel(array $cfg, array $machines, array $recipient): ?array
+    {
+        $max = max(1, min(10, (int) ($cfg['max_cards'] ?? 10)));
+        $selected = array_slice($machines, 0, $max);
+        if ($selected === []) {
+            return null;
+        }
+        $cards = [];
+        foreach ($selected as $idx => $machine) {
+            $ctx = [$machine];
+            $card_components = [];
+
+            if (!empty($cfg['header_image'])) {
+                $link = trim($this->evaluate((string) $cfg['header_image'], $ctx, $recipient));
+                if ($link !== '') {
+                    $card_components[] = [
+                        'type'       => 'header',
+                        'parameters' => [[
+                            'type'  => 'image',
+                            'image' => ['link' => $link],
+                        ]],
+                    ];
+                }
+            }
+
+            if (!empty($cfg['body']) && is_array($cfg['body'])) {
+                $is_named = $this->is_assoc($cfg['body']);
+                $params = [];
+                foreach ($cfg['body'] as $key => $expr) {
+                    $param = [
+                        'type' => 'text',
+                        'text' => self::sanitize_param($this->evaluate((string) $expr, $ctx, $recipient)),
+                    ];
+                    if ($is_named) {
+                        $param['parameter_name'] = (string) $key;
+                    }
+                    $params[] = $param;
+                }
+                $card_components[] = ['type' => 'body', 'parameters' => $params];
+            }
+
+            if (!empty($cfg['buttons']) && is_array($cfg['buttons'])) {
+                foreach ($cfg['buttons'] as $btn_index => $btn) {
+                    if (!is_array($btn) || empty($btn['sub_type'])) {
+                        continue;
+                    }
+                    $sub = (string) $btn['sub_type'];
+                    $value = self::sanitize_param($this->evaluate((string) ($btn['param'] ?? ''), $ctx, $recipient));
+                    $param_type = $sub === 'quick_reply' ? 'payload' : 'text';
+                    $param_key = $sub === 'quick_reply' ? 'payload' : 'text';
+                    $card_components[] = [
+                        'type'       => 'button',
+                        'sub_type'   => $sub,
+                        'index'      => (string) $btn_index,
+                        'parameters' => [[
+                            'type'      => $param_type,
+                            $param_key  => $value,
+                        ]],
+                    ];
+                }
+            }
+
+            $cards[] = [
+                'card_index' => $idx,
+                'components' => $card_components,
+            ];
+        }
+
+        return [
+            'type'  => 'carousel',
+            'cards' => $cards,
+        ];
     }
 
     public function evaluate(string $expression, array $machines, array $recipient = []): string
@@ -116,6 +211,22 @@ final class TemplateRenderer
 
         $expression = preg_replace_callback('/\{bullets:([^}]+)\}/u', static function (array $m) use ($machines): string {
             return self::join_columns($machines, $m[1], ' • ', '');
+        }, $expression) ?? $expression;
+
+        $expression = preg_replace_callback('/\{img:([^}]+)\}/u', static function (array $m) use ($machines): string {
+            $col = trim($m[1]);
+            $val = trim((string) ($machines[0][$col] ?? ''));
+            if ($val === '') {
+                return '';
+            }
+            if (preg_match('#^https?://#i', $val)) {
+                return $val;
+            }
+            $pattern = trim((string) Settings::get('image_url_pattern', ''));
+            if ($pattern === '' || strpos($pattern, '{value}') === false) {
+                return $val;
+            }
+            return str_replace('{value}', rawurlencode($val), $pattern);
         }, $expression) ?? $expression;
 
         return $expression;

--- a/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
@@ -16,7 +16,9 @@ use InfraSe\ExcavatorDispatch\Support\Settings;
  *
  * Expressions supported in any value:
  *   {col:Name}         first machine's "Name" column
- *   {list:Col1,Col2}   bullet list joining the columns for every machine
+ *   {list:Col1,Col2}   inline list joining the columns for every machine
+ *                      (uses " · " as separator — WhatsApp rejects parameters
+ *                      with newlines, tabs, or 5+ consecutive spaces)
  *   {count}            number of selected machines
  *   {recipient_name}   contact display name
  *   {recipient_phone}  contact phone (E.164)
@@ -44,7 +46,7 @@ final class TemplateRenderer
             foreach ($config[$type] as $key => $expr) {
                 $param = [
                     'type' => 'text',
-                    'text' => $this->evaluate((string) $expr, $machines, $recipient),
+                    'text' => self::sanitize_param($this->evaluate((string) $expr, $machines, $recipient)),
                 ];
                 if ($is_named) {
                     $param['parameter_name'] = (string) $key;
@@ -88,23 +90,31 @@ final class TemplateRenderer
 
         $expression = preg_replace_callback('/\{list:([^}]+)\}/u', static function (array $m) use ($machines): string {
             $cols = array_map('trim', explode(',', $m[1]));
-            $lines = [];
+            $items = [];
             foreach ($machines as $row) {
                 $parts = [];
                 foreach ($cols as $c) {
-                    $v = (string) ($row[$c] ?? '');
+                    $v = trim((string) ($row[$c] ?? ''));
                     if ($v !== '') {
                         $parts[] = $v;
                     }
                 }
                 if (!empty($parts)) {
-                    $lines[] = '- ' . implode(' ', $parts);
+                    $items[] = implode(' ', $parts);
                 }
             }
-            return implode("\n", $lines);
+            return implode(' · ', $items);
         }, $expression) ?? $expression;
 
         return $expression;
+    }
+
+    private static function sanitize_param(string $text): string
+    {
+        // WhatsApp rejects parameters containing newlines, tabs, or 5+ spaces.
+        $text = str_replace(["\r\n", "\r", "\n", "\t"], ' ', $text);
+        $text = preg_replace('/ {4,}/', '   ', $text) ?? $text;
+        return trim($text);
     }
 
     private function is_assoc(array $arr): bool

--- a/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
@@ -16,15 +16,18 @@ use InfraSe\ExcavatorDispatch\Support\Settings;
  *
  * Expressions supported in any value:
  *   {col:Name}         first machine's "Name" column
- *   {list:Col1,Col2}   inline list joined by ' · ' (always safe)
- *   {bullets:Col1,Col2} newline-separated bulleted list "• …"
- *                      (some WhatsApp template categories reject newlines;
- *                      if Meta returns #100 Invalid parameter, fall back to {list:…})
+ *   {list:Col1,Col2}   inline list joined by ' · '
+ *   {bullets:Col1,Col2} inline list joined by ' • '
  *   {count}            number of selected machines
  *   {recipient_name}   contact display name
  *   {recipient_phone}  contact phone (E.164)
  *   {recipient_org}    contact organization
  *   literal text       used as-is
+ *
+ * NOTE: WhatsApp Cloud API rejects parameters containing newlines, tabs,
+ * or 5+ consecutive spaces. Vertical bulleted lists are not possible
+ * inside a single parameter — design the template body accordingly
+ * (e.g. put line breaks in the template itself, around the placeholder).
  */
 final class TemplateRenderer
 {
@@ -94,7 +97,7 @@ final class TemplateRenderer
         }, $expression) ?? $expression;
 
         $expression = preg_replace_callback('/\{bullets:([^}]+)\}/u', static function (array $m) use ($machines): string {
-            return self::join_columns($machines, $m[1], "\n", '• ');
+            return self::join_columns($machines, $m[1], ' • ', '');
         }, $expression) ?? $expression;
 
         return $expression;
@@ -102,11 +105,8 @@ final class TemplateRenderer
 
     private static function sanitize_param(string $text): string
     {
-        // Normalise line endings, strip tabs, collapse 5+ spaces.
-        // Newlines are left intact — {bullets:…} needs them and modern Cloud
-        // API accepts them for most template categories.
-        $text = str_replace(["\r\n", "\r"], "\n", $text);
-        $text = str_replace("\t", ' ', $text);
+        // WhatsApp rejects parameters with newlines, tabs, or 5+ consecutive spaces.
+        $text = str_replace(["\r\n", "\r", "\n", "\t"], ' ', $text);
         $text = preg_replace('/ {4,}/', '   ', $text) ?? $text;
         return trim($text);
     }

--- a/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Services;
+
+use InfraSe\ExcavatorDispatch\Support\Settings;
+
+/**
+ * Builds the components[] payload for a WhatsApp template call.
+ *
+ * The mapping configured in settings ties each template variable to an
+ * expression that is evaluated against the list of selected machines.
+ *
+ * Supported expressions:
+ *  - {col:Name}                  -> first machine's "Name" column
+ *  - {list:Modello,Anno}         -> bullet list joining the given columns for every selected machine
+ *  - {count}                     -> number of selected machines
+ *  - literal text                -> used as-is
+ */
+final class TemplateRenderer
+{
+    public function build_components(string $template_name, array $machines): array
+    {
+        $mappings = (array) Settings::get('template_mappings', []);
+        $config = $mappings[$template_name] ?? null;
+        if (!is_array($config) || empty($config)) {
+            return [];
+        }
+
+        $components = [];
+
+        foreach (['header', 'body', 'footer'] as $type) {
+            if (empty($config[$type]) || !is_array($config[$type])) {
+                continue;
+            }
+            $params = [];
+            foreach ($config[$type] as $expr) {
+                $params[] = [
+                    'type' => 'text',
+                    'text' => $this->evaluate((string) $expr, $machines),
+                ];
+            }
+            if (!empty($params)) {
+                $components[] = [
+                    'type'       => $type,
+                    'parameters' => $params,
+                ];
+            }
+        }
+        return $components;
+    }
+
+    public function evaluate(string $expression, array $machines): string
+    {
+        $expression = (string) $expression;
+        $expression = preg_replace_callback('/\{count\}/', static function () use ($machines): string {
+            return (string) count($machines);
+        }, $expression) ?? $expression;
+
+        $expression = preg_replace_callback('/\{col:([^}]+)\}/u', static function (array $m) use ($machines): string {
+            $col = trim($m[1]);
+            return (string) ($machines[0][$col] ?? '');
+        }, $expression) ?? $expression;
+
+        $expression = preg_replace_callback('/\{list:([^}]+)\}/u', static function (array $m) use ($machines): string {
+            $cols = array_map('trim', explode(',', $m[1]));
+            $lines = [];
+            foreach ($machines as $row) {
+                $parts = [];
+                foreach ($cols as $c) {
+                    $v = (string) ($row[$c] ?? '');
+                    if ($v !== '') {
+                        $parts[] = $v;
+                    }
+                }
+                if (!empty($parts)) {
+                    $lines[] = '- ' . implode(' ', $parts);
+                }
+            }
+            return implode("\n", $lines);
+        }, $expression) ?? $expression;
+
+        return $expression;
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
+++ b/public/content/plugins/excavator-dispatch/src/Services/TemplateRenderer.php
@@ -16,9 +16,10 @@ use InfraSe\ExcavatorDispatch\Support\Settings;
  *
  * Expressions supported in any value:
  *   {col:Name}         first machine's "Name" column
- *   {list:Col1,Col2}   inline list joining the columns for every machine
- *                      (uses " · " as separator — WhatsApp rejects parameters
- *                      with newlines, tabs, or 5+ consecutive spaces)
+ *   {list:Col1,Col2}   inline list joined by ' · ' (always safe)
+ *   {bullets:Col1,Col2} newline-separated bulleted list "• …"
+ *                      (some WhatsApp template categories reject newlines;
+ *                      if Meta returns #100 Invalid parameter, fall back to {list:…})
  *   {count}            number of selected machines
  *   {recipient_name}   contact display name
  *   {recipient_phone}  contact phone (E.164)
@@ -89,21 +90,11 @@ final class TemplateRenderer
         }, $expression) ?? $expression;
 
         $expression = preg_replace_callback('/\{list:([^}]+)\}/u', static function (array $m) use ($machines): string {
-            $cols = array_map('trim', explode(',', $m[1]));
-            $items = [];
-            foreach ($machines as $row) {
-                $parts = [];
-                foreach ($cols as $c) {
-                    $v = trim((string) ($row[$c] ?? ''));
-                    if ($v !== '') {
-                        $parts[] = $v;
-                    }
-                }
-                if (!empty($parts)) {
-                    $items[] = implode(' ', $parts);
-                }
-            }
-            return implode(' · ', $items);
+            return self::join_columns($machines, $m[1], ' · ', '');
+        }, $expression) ?? $expression;
+
+        $expression = preg_replace_callback('/\{bullets:([^}]+)\}/u', static function (array $m) use ($machines): string {
+            return self::join_columns($machines, $m[1], "\n", '• ');
         }, $expression) ?? $expression;
 
         return $expression;
@@ -111,10 +102,32 @@ final class TemplateRenderer
 
     private static function sanitize_param(string $text): string
     {
-        // WhatsApp rejects parameters containing newlines, tabs, or 5+ spaces.
-        $text = str_replace(["\r\n", "\r", "\n", "\t"], ' ', $text);
+        // Normalise line endings, strip tabs, collapse 5+ spaces.
+        // Newlines are left intact — {bullets:…} needs them and modern Cloud
+        // API accepts them for most template categories.
+        $text = str_replace(["\r\n", "\r"], "\n", $text);
+        $text = str_replace("\t", ' ', $text);
         $text = preg_replace('/ {4,}/', '   ', $text) ?? $text;
         return trim($text);
+    }
+
+    private static function join_columns(array $machines, string $cols_csv, string $sep, string $prefix): string
+    {
+        $cols = array_map('trim', explode(',', $cols_csv));
+        $items = [];
+        foreach ($machines as $row) {
+            $parts = [];
+            foreach ($cols as $c) {
+                $v = trim((string) ($row[$c] ?? ''));
+                if ($v !== '') {
+                    $parts[] = $v;
+                }
+            }
+            if (!empty($parts)) {
+                $items[] = $prefix . implode(' ', $parts);
+            }
+        }
+        return implode($sep, $items);
     }
 
     private function is_assoc(array $arr): bool

--- a/public/content/plugins/excavator-dispatch/src/Support/Cache.php
+++ b/public/content/plugins/excavator-dispatch/src/Support/Cache.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Support;
+
+final class Cache
+{
+    public const TTL_DEFAULT = 300;
+
+    public static function remember(string $key, int $ttl, callable $producer)
+    {
+        $full = 'excdis_' . $key;
+        $hit = get_transient($full);
+        if ($hit !== false) {
+            return $hit;
+        }
+        $value = $producer();
+        set_transient($full, $value, $ttl);
+        return $value;
+    }
+
+    public static function forget(string $key): void
+    {
+        delete_transient('excdis_' . $key);
+    }
+
+    public static function flush(): void
+    {
+        global $wpdb;
+        $like = $wpdb->esc_like('_transient_excdis_') . '%';
+        $wpdb->query($wpdb->prepare("DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $like));
+        $like2 = $wpdb->esc_like('_transient_timeout_excdis_') . '%';
+        $wpdb->query($wpdb->prepare("DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $like2));
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Support/Cache.php
+++ b/public/content/plugins/excavator-dispatch/src/Support/Cache.php
@@ -25,8 +25,19 @@ final class Cache
         delete_transient('excdis_' . $key);
     }
 
+    private const KNOWN_KEYS = [
+        'graph_token',
+        'google_token',
+        'machines_rows',
+        'recipients_contacts',
+        'whatsapp_templates',
+    ];
+
     public static function flush(): void
     {
+        foreach (self::KNOWN_KEYS as $k) {
+            self::forget($k);
+        }
         global $wpdb;
         $like = $wpdb->esc_like('_transient_excdis_') . '%';
         $wpdb->query($wpdb->prepare("DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", $like));

--- a/public/content/plugins/excavator-dispatch/src/Support/Logger.php
+++ b/public/content/plugins/excavator-dispatch/src/Support/Logger.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Support;
+
+final class Logger
+{
+    public static function table(): string
+    {
+        global $wpdb;
+        return $wpdb->prefix . 'excdis_dispatches';
+    }
+
+    public static function install_table(): void
+    {
+        global $wpdb;
+        $table = self::table();
+        $charset = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            created_at DATETIME NOT NULL,
+            user_id BIGINT UNSIGNED NOT NULL,
+            template_name VARCHAR(190) NOT NULL,
+            template_language VARCHAR(10) NOT NULL,
+            machine_count SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+            recipient_count SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+            success_count SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+            error_count SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+            details LONGTEXT NULL,
+            PRIMARY KEY (id),
+            KEY created_at (created_at)
+        ) {$charset};";
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($sql);
+    }
+
+    public static function record(array $row): int
+    {
+        global $wpdb;
+        $wpdb->insert(self::table(), [
+            'created_at'        => current_time('mysql'),
+            'user_id'           => get_current_user_id(),
+            'template_name'     => (string) ($row['template_name'] ?? ''),
+            'template_language' => (string) ($row['template_language'] ?? ''),
+            'machine_count'     => (int) ($row['machine_count'] ?? 0),
+            'recipient_count'   => (int) ($row['recipient_count'] ?? 0),
+            'success_count'     => (int) ($row['success_count'] ?? 0),
+            'error_count'       => (int) ($row['error_count'] ?? 0),
+            'details'           => wp_json_encode($row['details'] ?? []),
+        ]);
+        return (int) $wpdb->insert_id;
+    }
+
+    public static function recent(int $limit = 50): array
+    {
+        global $wpdb;
+        $table = self::table();
+        $limit = max(1, min($limit, 500));
+        $rows = $wpdb->get_results("SELECT * FROM {$table} ORDER BY id DESC LIMIT {$limit}", ARRAY_A);
+        return is_array($rows) ? $rows : [];
+    }
+}

--- a/public/content/plugins/excavator-dispatch/src/Support/Logger.php
+++ b/public/content/plugins/excavator-dispatch/src/Support/Logger.php
@@ -60,4 +60,22 @@ final class Logger
         $rows = $wpdb->get_results("SELECT * FROM {$table} ORDER BY id DESC LIMIT {$limit}", ARRAY_A);
         return is_array($rows) ? $rows : [];
     }
+
+    public static function delete_older_than(int $days): int
+    {
+        global $wpdb;
+        $days = max(0, $days);
+        $cutoff = gmdate('Y-m-d H:i:s', time() - $days * DAY_IN_SECONDS);
+        $deleted = $wpdb->query(
+            $wpdb->prepare("DELETE FROM " . self::table() . " WHERE created_at < %s", $cutoff)
+        );
+        return (int) $deleted;
+    }
+
+    public static function delete_all(): int
+    {
+        global $wpdb;
+        $deleted = $wpdb->query("DELETE FROM " . self::table());
+        return (int) $deleted;
+    }
 }

--- a/public/content/plugins/excavator-dispatch/src/Support/Settings.php
+++ b/public/content/plugins/excavator-dispatch/src/Support/Settings.php
@@ -43,7 +43,7 @@ final class Settings
     {
         $sanitized = [];
         foreach ($values as $k => $v) {
-            $sanitized[(string) $k] = is_string($v) ? wp_unslash($v) : $v;
+            $sanitized[(string) $k] = $v;
         }
         foreach (self::SECRET_KEYS as $key) {
             if (!empty($sanitized[$key])) {

--- a/public/content/plugins/excavator-dispatch/src/Support/Settings.php
+++ b/public/content/plugins/excavator-dispatch/src/Support/Settings.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfraSe\ExcavatorDispatch\Support;
+
+final class Settings
+{
+    private const OPTION = 'excdis_settings';
+
+    private const SECRET_KEYS = [
+        'm365_client_secret',
+        'google_service_account_json',
+        'whatsapp_access_token',
+    ];
+
+    private static ?array $cache = null;
+
+    public static function all(): array
+    {
+        if (self::$cache !== null) {
+            return self::$cache;
+        }
+        $raw = get_option(self::OPTION, []);
+        if (!is_array($raw)) {
+            $raw = [];
+        }
+        foreach (self::SECRET_KEYS as $key) {
+            if (!empty($raw[$key])) {
+                $raw[$key] = self::decrypt((string) $raw[$key]);
+            }
+        }
+        return self::$cache = $raw;
+    }
+
+    public static function get(string $key, $default = null)
+    {
+        $all = self::all();
+        return $all[$key] ?? $default;
+    }
+
+    public static function save(array $values): void
+    {
+        $sanitized = [];
+        foreach ($values as $k => $v) {
+            $sanitized[(string) $k] = is_string($v) ? wp_unslash($v) : $v;
+        }
+        foreach (self::SECRET_KEYS as $key) {
+            if (!empty($sanitized[$key])) {
+                $sanitized[$key] = self::encrypt((string) $sanitized[$key]);
+            }
+        }
+        update_option(self::OPTION, $sanitized);
+        self::$cache = null;
+    }
+
+    public static function is_configured(): bool
+    {
+        $s = self::all();
+        return !empty($s['m365_tenant_id'])
+            && !empty($s['m365_client_id'])
+            && !empty($s['m365_client_secret'])
+            && !empty($s['whatsapp_phone_number_id'])
+            && !empty($s['whatsapp_access_token']);
+    }
+
+    private static function key(): string
+    {
+        if (defined('EXCDIS_ENCRYPTION_KEY') && is_string(EXCDIS_ENCRYPTION_KEY) && strlen(EXCDIS_ENCRYPTION_KEY) >= 32) {
+            return substr((string) EXCDIS_ENCRYPTION_KEY, 0, 32);
+        }
+        $fallback = defined('AUTH_KEY') ? AUTH_KEY : 'excdis-fallback-key-please-override';
+        return substr(hash('sha256', (string) $fallback, true), 0, 32);
+    }
+
+    private static function encrypt(string $plain): string
+    {
+        if (!function_exists('sodium_crypto_secretbox')) {
+            return base64_encode($plain);
+        }
+        $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $cipher = sodium_crypto_secretbox($plain, $nonce, self::key());
+        return 'v1:' . base64_encode($nonce . $cipher);
+    }
+
+    private static function decrypt(string $value): string
+    {
+        if (strncmp($value, 'v1:', 3) !== 0) {
+            $decoded = base64_decode($value, true);
+            return $decoded === false ? '' : $decoded;
+        }
+        if (!function_exists('sodium_crypto_secretbox_open')) {
+            return '';
+        }
+        $bin = base64_decode(substr($value, 3), true);
+        if ($bin === false || strlen($bin) < SODIUM_CRYPTO_SECRETBOX_NONCEBYTES + 1) {
+            return '';
+        }
+        $nonce = substr($bin, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $cipher = substr($bin, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $plain = sodium_crypto_secretbox_open($cipher, $nonce, self::key());
+        return $plain === false ? '' : $plain;
+    }
+}


### PR DESCRIPTION
## Summary
- Plugin WordPress `excavator-dispatch` in `public/content/plugins/excavator-dispatch/` (PSR-4, PHP 7.4+).
- Filtra escavatori da un foglio Excel su Microsoft 365 (Graph API, client credentials), destinatari da Google Contacts (People API + service account con domain-wide delegation) e invia un template WhatsApp via Cloud API (Meta).
- Pagina admin di invio con multi-select macchine + destinatari, anteprima template, log per destinatario; pagina settings con credenziali crittografate (`sodium_crypto_secretbox`); storico invii su tabella custom `wp_excdis_dispatches`.

## Implementazione
- **REST**: `/wp-json/excavator-dispatch/v1/{machines,recipients,templates,dispatch}` con cache transient e capability `manage_options`.
- **Filtri**: configurabili da UI (regole "col op value") per macchine; gruppi Google + regex nome + presenza telefono per destinatari.
- **Mapping template**: JSON in settings con espressioni `{col:X}`, `{list:Col1,Col2}`, `{count}` o testo libero.
- **Sicurezza**: nonce WP su tutte le rotte, segreti cifrati a riposo, sanitizzazione/validazione input, throttle soft ~20 msg/s.

## Test plan
- [ ] `composer install --no-dev -o` nella cartella plugin.
- [ ] Definire `EXCDIS_ENCRYPTION_KEY` in `wp-config.php`.
- [ ] Configurare credenziali M365, Google SA (con domain-wide delegation), WhatsApp Cloud (Phone Number ID, WABA ID, token).
- [ ] Aprire menu WP "Excavator Dispatch", verificare caricamento macchine e destinatari.
- [ ] Eseguire un invio di prova su 1-2 numeri con un template approvato in lingua di default.
- [ ] Verificare riga in "Storico invii" con esito per destinatario.

## Punti aperti / fase 2
- Webhook delivery/read receipts.
- Invio asincrono in coda (per volumi > qualche centinaio).
- Editor template integrato (oggi gestiti su Meta Business Manager).

---
_Generated by [Claude Code](https://claude.ai/code/session_018Zr7RyRrTqTp4PQv2bhKby)_